### PR TITLE
fix: set timestamp via `evm_setNextBlockTimestamp`

### DIFF
--- a/ape_foundry/providers.py
+++ b/ape_foundry/providers.py
@@ -235,9 +235,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         return self._web3.manager.request_blocking(rpc, args)  # type: ignore
 
     def set_timestamp(self, new_timestamp: int):
-        pending_timestamp = self.get_block("pending").timestamp
-        seconds_to_increase = new_timestamp - pending_timestamp
-        self._make_request("evm_increaseTime", [seconds_to_increase])
+        self._make_request("evm_setNextBlockTimestamp", [new_timestamp])
 
     def mine(self, num_blocks: int = 1):
         self._make_request("evm_mine", [{"blocks": num_blocks}])

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -100,9 +100,6 @@ def test_multiple_instances(network_api):
     assert hash_1 != hash_2 != hash_3
 
 
-@pytest.mark.xfail(
-    reason="Waiting for https://github.com/foundry-rs/foundry/issues/1511 to be resolved"
-)
 def test_set_timestamp(foundry_connected):
     start_time = foundry_connected.get_block("pending").timestamp
     foundry_connected.set_timestamp(start_time + 5)  # Increase by 5 seconds


### PR DESCRIPTION
### What I did

Pending block/timestamp support was added in Foundry, but didn't work because `evm_increaseTime` was broken. Thankfully, `evm_setNextBlockTimestamp` does actually work instead

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
