### PR TITLE
feat: detect evm version when forking from a certain height

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ foundry:
 
 ```
 
-Otherwise, it defaults to the default mainnet provider plugin. You can also specify a ``block_number``.
+Otherwise, it defaults to the default mainnet provider plugin. You can also specify a ``block_number`` and ``evm_version``.
+
+If the block number is specified, but no EVM version is specified, it is automatically set based on the block height for known networks.
 
 **NOTE**: Make sure you have the upstream provider plugin installed for ape.
 

--- a/ape_foundry/constants.py
+++ b/ape_foundry/constants.py
@@ -1,0 +1,55 @@
+# Extracted from Erigon chain specs
+# https://github.com/ledgerwatch/erigon/tree/devel/params/chainspecs
+# https://gist.github.com/banteg/e38c7d98f35286c303311168f28404ca
+EVM_VERSION_BY_NETWORK = {
+    "ethereum": {
+        "mainnet": {
+            1150000: "homestead",
+            4370000: "byzantine",  # foundry uses this name for the byzantium fork
+            7280000: "petersburg",
+            9069000: "istanbul",
+            9200000: "muirglacier",
+            12244000: "berlin",
+            12965000: "london",
+        },
+        "ropsten": {
+            0: "homestead",
+            1700000: "byzantine",
+            4230000: "constantinople",
+            4939394: "petersburg",
+            6485846: "istanbul",
+            7117117: "muirglacier",
+            9812189: "berlin",
+            10499401: "london",
+        },
+        "rinkeby": {
+            1: "homestead",
+            1035301: "byzantine",
+            3660663: "constantinople",
+            4321234: "petersburg",
+            5435345: "istanbul",
+            8290928: "berlin",
+            8897988: "london",
+        },
+        "goerli": {
+            0: "petersburg",
+            1561651: "istanbul",
+            4460644: "berlin",
+            5062605: "london",
+        },
+    },
+    "polygon": {
+        "mainnet": {
+            0: "petersburg",
+            3395000: "muirglacier",
+            14750000: "berlin",
+            23850000: "london",
+        },
+        "mumbai": {
+            0: "petersburg",
+            2722000: "muirglacier",
+            13996000: "berlin",
+            22640000: "london",
+        },
+    },
+}

--- a/ape_foundry/constants.py
+++ b/ape_foundry/constants.py
@@ -6,7 +6,7 @@ EVM_VERSION_BY_NETWORK = {
         "mainnet": {
             0: "frontier",
             1150000: "homestead",
-            4370000: "byzantine",  # foundry uses this name for the byzantium fork
+            4370000: "byzantium",
             7280000: "petersburg",
             9069000: "istanbul",
             9200000: "muirglacier",
@@ -15,7 +15,7 @@ EVM_VERSION_BY_NETWORK = {
         },
         "ropsten": {
             0: "homestead",
-            1700000: "byzantine",
+            1700000: "byzantium",
             4230000: "constantinople",
             4939394: "petersburg",
             6485846: "istanbul",
@@ -25,7 +25,7 @@ EVM_VERSION_BY_NETWORK = {
         },
         "rinkeby": {
             1: "homestead",
-            1035301: "byzantine",
+            1035301: "byzantium",
             3660663: "constantinople",
             4321234: "petersburg",
             5435345: "istanbul",

--- a/ape_foundry/constants.py
+++ b/ape_foundry/constants.py
@@ -4,6 +4,7 @@
 EVM_VERSION_BY_NETWORK = {
     "ethereum": {
         "mainnet": {
+            0: "frontier",
             1150000: "homestead",
             4370000: "byzantine",  # foundry uses this name for the byzantium fork
             7280000: "petersburg",

--- a/ape_foundry/providers.py
+++ b/ape_foundry/providers.py
@@ -33,6 +33,8 @@ from web3 import HTTPProvider, Web3
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 
+from ape_foundry.constants import EVM_VERSION_BY_NETWORK
+
 from .exceptions import FoundryNotInstalledError, FoundryProviderError, FoundrySubprocessError
 
 EPHEMERAL_PORTS_START = 49152
@@ -41,22 +43,6 @@ FOUNDRY_START_NETWORK_RETRIES = [0.1, 0.2, 0.3, 0.5, 1.0]  # seconds between net
 FOUNDRY_START_PROCESS_ATTEMPTS = 3  # number of attempts to start subprocess before giving up
 DEFAULT_PORT = 8545
 FOUNDRY_CHAIN_ID = 31337
-EVM_VERSION_BY_NETWORK = {
-    "ethereum": {
-        "mainnet": {
-            0: "frontier",
-            1_150_000: "homestead",
-            2_463_000: "tangerine",
-            2_675_000: "spuriousdragon",
-            4_370_000: "byzantine",
-            7_280_000: "petersburg",
-            9_069_000: "istanbul",
-            9_200_000: "muirglacier",
-            12_244_000: "berlin",
-            12_965_000: "london",
-        }
-    }
-}
 
 
 class FoundryForkConfig(PluginConfig):

--- a/ape_foundry/providers.py
+++ b/ape_foundry/providers.py
@@ -40,6 +40,20 @@ FOUNDRY_START_NETWORK_RETRIES = [0.1, 0.2, 0.3, 0.5, 1.0]  # seconds between net
 FOUNDRY_START_PROCESS_ATTEMPTS = 3  # number of attempts to start subprocess before giving up
 DEFAULT_PORT = 8545
 FOUNDRY_CHAIN_ID = 31337
+FORKS_BY_CHAIN_ID = {
+    1: {
+        0: "frontier",
+        1_150_000: "homestead",
+        2_463_000: "tangerine",
+        2_675_000: "spuriousdragon",
+        4_370_000: "byzantine",
+        7_280_000: "petersburg",
+        9_069_000: "istanbul",
+        9_200_000: "muirglacier",
+        12_244_000: "berlin",
+        12_965_000: "london",
+    }
+}
 
 
 class FoundryForkConfig(PluginConfig):

--- a/ape_foundry/providers.py
+++ b/ape_foundry/providers.py
@@ -59,6 +59,7 @@ FORKS_BY_CHAIN_ID = {
 class FoundryForkConfig(PluginConfig):
     upstream_provider: Optional[str] = None
     block_number: Optional[int] = None
+    evm_version: Optional[str] = None
 
 
 class FoundryNetworkConfig(PluginConfig):


### PR DESCRIPTION
### What I did
- allow specifying `evm_version` in fork config
- automatically choose the correct fork if a block number is specified

### How I did it
- add `ecosystem:network:start_block:evm_version` mapping
- hardcode block to fork mapping for ethereum mainnet
- guess version from upsteam provider if block is provided but evm version is not provided, providing less surprising behavior when forking from older blocks
- add a `--hardfork` argument to `anvil` if we run something other than the latest fork

### How to verify it
fork from an old block

### References
- [foundry hardfork options](https://github.com/foundry-rs/foundry/blob/03b6f2c458634859ee1c35bbcb74f0dff75f27e1/anvil/src/config.rs#L676-L687)
- [erigon chain specs](https://github.com/ledgerwatch/erigon/tree/devel/params/chainspecs)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
