### PR TITLE
feat!: add raise_on_fail to send_transaction()

### DIFF
--- a/ape_foundry/providers.py
+++ b/ape_foundry/providers.py
@@ -315,7 +315,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         self.unlocked_accounts.append(address)
         return True
 
-    def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
+    def send_transaction(self, txn: TransactionAPI, raise_on_fail: bool = True) -> ReceiptAPI:
         """
         Creates a new message call transaction or a contract creation
         for signed transactions.
@@ -344,9 +344,11 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
                 if original_code:
                     self.set_code(sender, original_code.hex())
         else:
-            receipt = super().send_transaction(txn)
+            receipt = super().send_transaction(txn, raise_on_fail=raise_on_fail)
 
-        receipt.raise_for_status()
+        if raise_on_fail:
+            receipt.raise_for_status()
+
         return receipt
 
     def get_balance(self, address: str) -> int:

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -191,6 +191,13 @@ def test_contract_revert_no_message(owner, contract_instance):
     assert str(err.value) == "Transaction failed."
 
 
+def test_contract_revert_no_raise(owner, contract_instance):
+    # The Contract raises empty revert when setting number to 5.
+    receipt = contract_instance.setNumber(5, sender=owner)
+
+    assert receipt.failed
+
+
 def test_get_call_tree(receipt, connected_provider, call_expression):
     actual = connected_provider.get_call_tree(receipt.txn_hash)
     assert call_expression.match(repr(actual))


### PR DESCRIPTION
### What I did

Added `raise_on_fail` per https://github.com/ApeWorX/ape/pull/957

### How to verify it

Added new test to verify

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
