### PR TITLE
fix: reset fork base fee

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -632,9 +632,13 @@ class FoundryForkProvider(FoundryProvider):
         result = self._make_request("anvil_reset", [{"forking": forking_params}])
 
         try:
-            # reset next block base fee to that of new chain head if can
-            self._make_request("anvil_setNextBlockBaseFeePerGas", [self.base_fee])
+            base_fee = self.base_fee
         except APINotImplementedError:
+            base_fee = None
             logger.warning("base_fee not found in block - base fee may not be reset.")
+
+        # reset next block base fee to that of new chain head if can
+        if base_fee is not None:
+            self._make_request("anvil_setNextBlockBaseFeePerGas", [base_fee])
 
         return result

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -630,6 +630,6 @@ class FoundryForkProvider(FoundryProvider):
             # reset next block base fee to that of new chain head if can
             self._make_request("anvil_setNextBlockBaseFeePerGas", [self.base_fee])
         except APINotImplementedError:
-            pass
+            logger.warning("base_fee not found in block - base fee may not be reset.")
 
         return result

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -17,6 +17,7 @@ from ape.api import (
     Web3Provider,
 )
 from ape.exceptions import (
+    APINotImplementedError,
     ContractLogicError,
     OutOfGasError,
     ProviderError,
@@ -623,4 +624,12 @@ class FoundryForkProvider(FoundryProvider):
         if block_number is not None:
             forking_params["blockNumber"] = block_number
 
-        return self._make_request("anvil_reset", [{"forking": forking_params}])
+        result = self._make_request("anvil_reset", [{"forking": forking_params}])
+
+        try:
+            # reset next block base fee to that of new chain head if can
+            self._make_request("anvil_setNextBlockBaseFeePerGas", [self.base_fee])
+        except APINotImplementedError:
+            pass
+
+        return result

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_require = {
         "twine",  # Package upload tool
     ],
     "dev": [
-        "commitizen>=2.19,<2.20",  # Manage commits and publishing releases
+        "commitizen",  # Manage commits and publishing releases
         "pre-commit",  # Ensure that linters are run prior to committing
         "IPython",  # Console for interacting
         "ipdb",  # Debugger (Must use `export PYTHONBREAKPOINT=ipdb.set_trace`)

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -109,7 +109,9 @@ def test_reset_fork_specify_block_number_via_config(mainnet_fork_provider):
     mainnet_fork_provider.mine(5)
     mainnet_fork_provider.reset_fork()
     block_num_after_reset = mainnet_fork_provider.get_block("latest").number
+    block_base_fee_after_reset = mainnet_fork_provider.get_block("latest").base_fee
     assert block_num_after_reset == 15776634  # Specified in ape-config.yaml
+    assert block_base_fee_after_reset == 28831496753
 
 
 @pytest.mark.fork


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #31 

### How I did it

After resetting fork to `block_number`, added call to `anvil_setNextBlockBaseFeePerGas` endpoint with `base_fee` of new forked chain state.

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
