### PR TITLE
feat: implement `get_transaction_trace()` [APE-750]

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -282,7 +282,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             f"{self.number_of_accounts}",
             "--derivation-path",
             "m/44'/60'/0'",
-            "--steps-tracing"
+            "--steps-tracing",
         ]
 
     def estimate_gas_cost(self, txn: TransactionAPI, **kwargs) -> int:

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 from ape.exceptions import ContractLogicError
-from ape.types import CallTreeNode
+from ape.types import CallTreeNode, TraceFrame
 from evm_trace import CallType
 from hexbytes import HexBytes
 
@@ -98,6 +98,16 @@ def test_unlock_account(connected_provider):
     actual = connected_provider.unlock_account(TEST_WALLET_ADDRESS)
     assert actual is True
     assert TEST_WALLET_ADDRESS in connected_provider.unlocked_accounts
+
+
+def test_get_transaction_trace(connected_provider, contract_instance, owner):
+    receipt = contract_instance.setNumber(10, sender=owner)
+
+    # Indirectly calls `connected_provider.get_transaction_trace()`
+    frame_data = list(receipt.trace)
+    assert frame_data
+    for frame in frame_data:
+        assert isinstance(frame, TraceFrame)
 
 
 def test_get_call_tree(connected_provider, sender, receiver):


### PR DESCRIPTION
### What I did

We hadn't implemented the `geth` style traces yet in this plugin.
They are needed for coverage and other features to work, so this implements the necessary API method.

### How I did it

Copy `ape-hardhat`
Also needed to add a new flag to the CLI startup.

### How to verify it

Works the same as `geth` and `hardhat` now.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
