### PR TITLE
fix: issue causing web3.py 6.0 to fail [APE-766]

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -216,7 +216,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         # Verify is actually a Foundry provider,
         # or else skip it to possibly try another port.
         # TODO: Once we are on web3.py 0.6.0b8 or later, can just use snake_case here.
-        client_version = getattr(self._web3, "client_version", getattr(self._web3, "clientVersion"))
+        client_version = getattr(
+            self._web3, "client_version", getattr(self._web3, "clientVersion", None)
+        )
 
         if "anvil" in client_version.lower():
             self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)


### PR DESCRIPTION
### What I did

stupid getattr mess up

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
