### PR TITLE
fix: del unneeded code after web3 6 [APE-768]

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -215,12 +215,8 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
         # Verify is actually a Foundry provider,
         # or else skip it to possibly try another port.
-        # TODO: Once we are on web3.py 0.6.0b8 or later, can just use snake_case here.
-        client_version = getattr(
-            self._web3, "client_version", getattr(self._web3, "clientVersion", None)
-        )
-
-        if "anvil" in client_version.lower():
+        client_version = self._web3.client_version.lower()
+        if "anvil" in client_version:
             self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
         else:
             raise ProviderError(

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     url="https://github.com/ApeWorX/ape-foundry",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.0,<0.7",
+        "eth-ape>=0.6.7,<0.7",
         "evm-trace>=0.1.0a13",
         "hexbytes",  # Use same version as eth-ape
         "web3",  # Use same version as eth-ape


### PR DESCRIPTION
### What I did

for when after https://github.com/ApeWorX/ape/pull/1361 releases

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
