### PR TITLE
fix: return exception instead of raise in `get_virtual_machine_error()` [APE-796]

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -531,7 +531,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             return OutOfGasError(txn=txn)
 
         elif message.startswith("execution reverted: "):
-            raise ContractLogicError(message.replace("execution reverted: ", "").strip(), txn=txn)
+            return ContractLogicError(message.replace("execution reverted: ", "").strip(), txn=txn)
 
         return VirtualMachineError(message, txn=txn)
 


### PR DESCRIPTION
### What I did

noticed we were raising when we should have been returning.
all it affects is the location of the exception, so not much, but is weird when looking at internal stack frames otherwise.

### How I did it

`raise` -> `return`

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
