### PR TITLE
feat: allow configuring `base_fee` and `priority_fee` [APE-847]

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -16,7 +16,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: pip install commitizen

--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -17,7 +17,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: pip install commitizen

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: |
@@ -47,7 +47,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: |
@@ -107,7 +107,7 @@ jobs:
 #        - name: Setup Python
 #          uses: actions/setup-python@v4
 #          with:
-#              python-version: 3.8
+#              python-version: "3.10"
 #
 #        - name: Install Dependencies
 #          run: pip install .[test]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ foundry:
     ethereum:
       mainnet:
         upstream_provider: alchemy
-
 ```
 
 Otherwise, it defaults to the default mainnet provider plugin.
@@ -99,3 +98,39 @@ foundry:
 ```
 
 Now, instead of launching a local process, it will attempt to connect to the remote anvil node and use this plugin as the ape interface.
+
+## Impersonate Accounts
+
+You can impersonate accounts using the `ape-foundry` plugin.
+To impersonate an account, do the following:
+
+```python
+import pytest
+
+@pytest.fixture
+def whale(accounts):
+    return accounts["example.ens"]
+```
+
+To transact, your impersonated account must have a balance.
+You can achieve this by using a forked network and impersonating an account with a balance.
+Alternatively, you can set your node's base fee and priority fee to `0`.
+
+To programtically set an account's balance, do the following:
+
+```python
+from ape import accounts
+
+account = accounts["example.ens"]
+account.balance = "1000 ETH"  # This calls `anvil_setBalance` under-the-hood.
+```
+
+## Base Fee and Priority Fee
+
+Configure your node's base fee and priority fee using the `ape-config.yaml` file.
+
+```yaml
+foundry:
+  base_fee: 0
+  priority_fee: 0
+```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ import pytest
 
 @pytest.fixture
 def whale(accounts):
-    return accounts["example.ens"]
+    return accounts["example.eth"]
 ```
 
 To transact, your impersonated account must have a balance.
@@ -121,7 +121,7 @@ To programtically set an account's balance, do the following:
 ```python
 from ape import accounts
 
-account = accounts["example.ens"]
+account = accounts["example.eth"]
 account.balance = "1000 ETH"  # This calls `anvil_setBalance` under-the-hood.
 ```
 

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -167,8 +167,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
     @property
     def priority_fee(self) -> int:
-        return 0
-        # return self.config.priority_fee
+        return self.config.priority_fee
 
     @property
     def is_connected(self) -> bool:
@@ -349,7 +348,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         super().disconnect()
 
     def build_command(self) -> List[str]:
-        cmd = [
+        return [
             self.anvil_bin,
             "--port",
             f"{self._port or DEFAULT_PORT}",
@@ -363,7 +362,6 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             "--block-base-fee-per-gas",
             f"{self.config.base_fee}",
         ]
-        return cmd
 
     def set_balance(self, account: AddressType, amount: Union[int, float, str, bytes]):
         is_str = isinstance(amount, str)

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -79,8 +79,8 @@ class FoundryNetworkConfig(PluginConfig):
     process_attempts: int = 0
 
     # RPC defaults
-    base_fee: int = int(10e8)  # 1 gwei
-    priority_fee: int = int(2e9)  # 2 gwei
+    base_fee: int = 0
+    priority_fee: int = 0
 
     # For setting the values in --fork and --fork-block-number command arguments.
     # Used only in FoundryForkProvider.

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -78,6 +78,10 @@ class FoundryNetworkConfig(PluginConfig):
     fork_request_timeout: int = 300
     process_attempts: int = 0
 
+    # RPC defaults
+    base_fee: int = int(10e8)  # 1 gwei
+    priority_fee: int = int(2e9)  # 2 gwei
+
     # For setting the values in --fork and --fork-block-number command arguments.
     # Used only in FoundryForkProvider.
     # Mapping of ecosystem_name => network_name => FoundryForkConfig
@@ -163,7 +167,8 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
     @property
     def priority_fee(self) -> int:
-        return self.conversion_manager.convert("2 gwei", int)
+        return 0
+        # return self.config.priority_fee
 
     @property
     def is_connected(self) -> bool:
@@ -344,7 +349,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         super().disconnect()
 
     def build_command(self) -> List[str]:
-        return [
+        cmd = [
             self.anvil_bin,
             "--port",
             f"{self._port or DEFAULT_PORT}",
@@ -355,7 +360,10 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             "--derivation-path",
             "m/44'/60'/0'",
             "--steps-tracing",
+            "--block-base-fee-per-gas",
+            f"{self.config.base_fee}",
         ]
+        return cmd
 
     def set_balance(self, account: AddressType, amount: Union[int, float, str, bytes]):
         is_str = isinstance(amount, str)
@@ -398,6 +406,11 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         self._make_request("anvil_impersonateAccount", [address])
         return True
 
+    def relock_account(self, address: AddressType):
+        self._make_request("anvil_stopImpersonatingAccount", [address])
+        if address in self.account_manager.test_accounts._impersonated_accounts:
+            del self.account_manager.test_accounts._impersonated_accounts[address]
+
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
         """
         Creates a new message call transaction or a contract creation
@@ -415,16 +428,16 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             if original_code:
                 self.set_code(sender, "")
 
+            txn_dict = txn.dict()
+            if isinstance(txn_dict.get("type"), int):
+                txn_dict["type"] = HexBytes(txn_dict["type"]).hex()
+
+            tx_params = cast(TxParams, txn_dict)
             try:
-                txn_dict = txn.dict()
-                if isinstance(txn_dict.get("type"), int):
-                    txn_dict["type"] = HexBytes(txn_dict["type"]).hex()
-
-                tx_params = cast(TxParams, txn_dict)
                 txn_hash = self.web3.eth.send_transaction(tx_params)
-
             except ValueError as err:
-                raise self.get_virtual_machine_error(err) from err
+                raise self.get_virtual_machine_error(err, txn=txn) from err
+
             finally:
                 if original_code:
                     self.set_code(sender, original_code.hex())
@@ -438,10 +451,15 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
                     # Add additional nonce information
                     new_err_msg = f"Nonce '{txn.nonce}' is too low"
                     raise VirtualMachineError(
-                        new_err_msg, base_err=vm_err.base_err, code=vm_err.code
+                        new_err_msg,
+                        base_err=vm_err.base_err,
+                        code=vm_err.code,
+                        txn=txn,
+                        source_traceback=vm_err.source_traceback,
+                        trace=vm_err.trace,
+                        contract_address=vm_err.contract_address,
                     )
 
-                vm_err.txn = txn
                 raise vm_err from err
 
         receipt = self.get_receipt(
@@ -468,8 +486,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             try:
                 self.web3.eth.call(txn_params)
             except Exception as err:
-                vm_err = self.get_virtual_machine_error(err, txn=txn)
-                vm_err.txn = txn
+                vm_err = self.get_virtual_machine_error(err, txn=receipt)
                 raise vm_err from err
 
         logger.info(f"Confirmed {receipt.txn_hash} (total fees paid = {receipt.total_fees_paid})")
@@ -621,7 +638,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
             return self.compiler_manager.enrich_error(err)
 
-        elif message == "Transaction ran out of gas":
+        elif message == "Transaction ran out of gas" or "OutOfGas" in message:
             return OutOfGasError(**kwargs)
 
         elif message.startswith("execution reverted: "):

--- a/setup.py
+++ b/setup.py
@@ -94,5 +94,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -15,6 +15,8 @@ polygon:
 foundry:
   request_timeout: 29
   fork_request_timeout: 360
+  priority_fee: 0
+  base_fee: 0
 
   fork:
     ethereum:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,3 +245,15 @@ def temp_config(config):
             config._cached_configs = {}
 
     return func
+
+
+@pytest.fixture
+def contract_a(owner, connected_provider, get_contract_type):
+    contract_c = owner.deploy(ContractContainer(get_contract_type("contract_c")))
+    contract_b = owner.deploy(
+        ContractContainer(get_contract_type("contract_b")), contract_c.address
+    )
+    contract_a = owner.deploy(
+        ContractContainer(get_contract_type("contract_a")), contract_b.address, contract_c.address
+    )
+    return contract_a

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -5,8 +5,6 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from ape.contracts import ContractContainer
-from ethpm_types import ContractType
 
 from .expected_traces import (
     LOCAL_GAS_REPORT,
@@ -53,22 +51,6 @@ def full_contracts_cache(config):
 )
 def mainnet_receipt(request, mainnet_fork_provider):
     return mainnet_fork_provider.get_receipt(request.param)
-
-
-@pytest.fixture
-def contract_a(owner, connected_provider):
-    base_path = BASE_CONTRACTS_PATH / "local"
-
-    def get_contract_type(suffix: str) -> ContractType:
-        return ContractType.parse_file(base_path / f"contract_{suffix}.json")
-
-    contract_c = owner.deploy(ContractContainer(get_contract_type("c")))
-    contract_b = owner.deploy(ContractContainer(get_contract_type("b")), contract_c.address)
-    contract_a = owner.deploy(
-        ContractContainer(get_contract_type("a")), contract_b.address, contract_c.address
-    )
-
-    return contract_a
 
 
 @pytest.fixture


### PR DESCRIPTION
### What I did

Noticed that `ape-hardhat` uses both `base_fee` and `priority_fee` values of `0`, which allows being able to use any account you want as an impersonated account, regardless of how much funds it has.

`ape-foundry` differs here. Instead, it defaults to having values returned for each field.
**We can discuss if we want to conform one or the other to the same (0.7 ?) or if it is ok to have them be different.**
But for now, to allow them to work the same if desired, allow configuring these fields.

### How I did it

* Add options to foundry config
* Honor options respectively
* Add test

### How to verify it

Create an use a config like:

```yaml
foundry:
  priority_fee: 0
  base_fee: 0
```

then crack open a console:

```bash
ape console --network ethereum:local:foundry
```

then check that it is set:

```python
In [1]: chain.provider.priority_fee
Out[1]: 2000000000
In [2]: In [1]: chain.provider.base_fee
Out[2]: 1000000000
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
