### PR TITLE
docs: correct misleading error message [APE-897]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Quick Start
 
-Foundry network provider plugin for Ape. Foundry is a development framework written in Rust for Ethereum that includes a local network implementation.
+Foundry network provider plugin for Ape.
+Foundry is a development framework written in Rust for Ethereum that includes a local network implementation.
 
 ## Dependencies
 
@@ -57,7 +58,8 @@ foundry:
 
 ## Mainnet Fork
 
-The `ape-foundry` plugin also includes a mainnet fork provider. It requires using another provider that has access to mainnet.
+The `ape-foundry` plugin also includes a mainnet fork provider.
+It requires using another provider that has access to mainnet.
 
 Use it in most commands like this:
 
@@ -76,7 +78,8 @@ foundry:
 
 ```
 
-Otherwise, it defaults to the default mainnet provider plugin. You can also specify a `block_number` and `evm_version`.
+Otherwise, it defaults to the default mainnet provider plugin.
+You can also specify a `block_number` and `evm_version`.
 
 If the block number is specified, but no EVM version is specified, it is automatically set based on the block height for known networks.
 

--- a/ape_foundry/exceptions.py
+++ b/ape_foundry/exceptions.py
@@ -20,8 +20,5 @@ class FoundryNotInstalledError(FoundrySubprocessError):
 
     def __init__(self):
         super().__init__(
-            "Missing local Foundry node client. "
-            "See ape-foundry README for install steps. "
-            "Note: global installation of Foundry will not work and "
-            "you must be in your project's directory."
+            "Missing local Foundry node client. See ape-foundry README for install steps."
         )


### PR DESCRIPTION
### What I did

error message was poorly copied from `ape-hardhat` and it is not true for `ape-foundry`

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
