### PR TITLE
feat: add get_auto_mine function [APE-998]

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -385,6 +385,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
     def set_timestamp(self, new_timestamp: int):
         self._make_request("evm_setNextBlockTimestamp", [new_timestamp])
 
+    def get_auto_mine(self) -> bool:
+        return self._make_request("anvil_getAutoMine", [])
+
     def mine(self, num_blocks: int = 1):
         result = self._make_request("evm_mine", [{"blocks": num_blocks, "timestamp": None}])
         if result != "0x0":

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -386,7 +386,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         self._make_request("evm_setNextBlockTimestamp", [new_timestamp])
 
     def get_auto_mine(self) -> bool:
-        return self._make_request("anvil_getAutoMine", [])
+        return self._make_request("anvil_getAutomine", [])
 
     def mine(self, num_blocks: int = 1):
         result = self._make_request("evm_mine", [{"blocks": num_blocks, "timestamp": None}])

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -186,6 +186,10 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
     def _test_config(self) -> TestConfig:
         return cast(TestConfig, self.config_manager.get_config("test"))
 
+    @property
+    def auto_mine(self) -> bool:
+        return self._make_request("anvil_getAutomine", [])
+
     def connect(self):
         """
         Start the foundry process and verify it's up and accepting connections.
@@ -388,9 +392,6 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
     def set_timestamp(self, new_timestamp: int):
         self._make_request("evm_setNextBlockTimestamp", [new_timestamp])
-
-    def get_auto_mine(self) -> bool:
-        return self._make_request("anvil_getAutomine", [])
 
     def mine(self, num_blocks: int = 1):
         result = self._make_request("evm_mine", [{"blocks": num_blocks, "timestamp": None}])

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -240,3 +240,7 @@ def test_host(temp_config, networks):
 
 def test_base_fee(connected_provider):
     assert connected_provider.base_fee == 0
+
+
+def test_automine(connected_provider):
+    assert connected_provider.auto_mine is True


### PR DESCRIPTION
### What I did

add anvil's `get_autoMine` call so you can tell what kind of behavior your anvil done is up to. reference: <https://book.getfoundry.sh/reference/anvil/>

### How I did it

added this code:
```py
    def get_auto_mine(self) -> bool:
        return self._make_request("anvil_getAutoMine", [])
```

### How to verify it

install the plugin, connect to an anvil node, and run `provider.get_auto_mine()`.

using `anvil` default:
```py
print(f"{provider.get_auto_mine()=}")
provider.get_auto_mine()=True
```

with `anvil --block-time 1` that mines a new block every 1 second... automatically?
```py
print(f"{provider.get_auto_mine()=}")
provider.get_auto_mine()=False
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
