### PR TITLE
fix: base fee not found in block err [APE-1021]

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -110,6 +110,10 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         return self._test_config.mnemonic
 
     @property
+    def base_fee(self) -> int:
+        return self.config.base_fee
+
+    @property
     def number_of_accounts(self) -> int:
         return self._test_config.number_of_accounts
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -236,3 +236,7 @@ def test_host(temp_config, networks):
     with temp_config(data):
         provider = networks.ethereum.local.get_provider("foundry")
         assert provider.uri == "https://example.com"
+
+
+def test_base_fee(connected_provider):
+    assert connected_provider.base_fee == 0


### PR DESCRIPTION
### What I did

some weird issue where base fee is not in the block.
thankfully, in foundry this is ok because we configure the base fee ahead of time and just return that value, so it is also a performance optimization in that sense.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
