### PR TITLE
fix: remote node check [APE-1110]

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -164,6 +164,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
     @property
     def uri(self) -> str:
+        if self.config.host:
+            if "https" not in self.config.host or "http" not in self.config.host:
+                self.config.host = "http://" + self.config.host  # type: ignore
         if self._host is None:
             self._host = self.config.host or f"http://127.0.0.1:{DEFAULT_PORT}"
 
@@ -222,7 +225,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             self._host = self.provider_settings["host"]
 
         elif self._host is None:
-            self._host = self.config.host or f"http://127.0.0.1:{DEFAULT_PORT}"
+            self._host = self.uri or f"http://127.0.0.1:{DEFAULT_PORT}"
 
         if self.is_connected:
             # Connects to already running process

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -77,7 +77,7 @@ class FoundryNetworkConfig(PluginConfig):
     # Retry strategy configs, try increasing these if you're getting FoundrySubprocessError
     request_timeout: int = 30
     fork_request_timeout: int = 300
-    process_attempts: int = 0
+    process_attempts: int = 5
 
     # RPC defaults
     base_fee: int = 0
@@ -168,6 +168,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         if self._host is not None:
             return self._host
         if config_host := self.config.host:
+            if config_host == "auto":
+                self._host = "auto"
+                return self._host
             if not config_host.startswith("http"):
                 if "127.0.0.1" in config_host or "localhost" in config_host:
                     self._host = f"http://{config_host}"
@@ -330,32 +333,31 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     def _start(self):
-        use_random_port = self.uri == "auto"
+        use_random_port = self._host == "auto"
         if use_random_port:
             self._host = None
 
-            if DEFAULT_PORT not in self.attempted_ports and not use_random_port:
+            if DEFAULT_PORT not in self.attempted_ports:
                 # First, attempt the default port before anything else.
                 self._host = f"127.0.0.1:{DEFAULT_PORT}"
 
-            else:
-                # Pick a random port
+            # Pick a random port
+            port = random.randint(EPHEMERAL_PORTS_START, EPHEMERAL_PORTS_END)
+            max_attempts = 25
+            attempts = 0
+            while port in self.attempted_ports:
                 port = random.randint(EPHEMERAL_PORTS_START, EPHEMERAL_PORTS_END)
-                max_attempts = 25
-                attempts = 0
-                while port in self.attempted_ports:
-                    port = random.randint(EPHEMERAL_PORTS_START, EPHEMERAL_PORTS_END)
-                    attempts += 1
-                    if attempts == max_attempts:
-                        ports_str = ", ".join([str(p) for p in self.attempted_ports])
-                        raise FoundryProviderError(
-                            f"Unable to find an available port. Ports tried: {ports_str}"
-                        )
+                attempts += 1
+                if attempts == max_attempts:
+                    ports_str = ", ".join([str(p) for p in self.attempted_ports])
+                    raise FoundryProviderError(
+                        f"Unable to find an available port. Ports tried: {ports_str}"
+                    )
 
-                self.attempted_ports.append(port)
-                self._host = f"http://127.0.0.1:{port}"
+            self.attempted_ports.append(port)
+            self._host = f"http://127.0.0.1:{port}"
 
-        elif ":" in self._host and self._port is not None:
+        elif self._host is not None and ":" in self._host and self._port is not None:
             # Append the one and only port to the attempted ports list, for honest keeping.
             self.attempted_ports.append(self._port)
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -231,7 +231,7 @@ def test_revert_error_using_impersonated_account(error_contract, accounts, conne
         error_contract.withdraw(sender=acct)
 
 
-@pytest.mark.parameterize("host", ("https://example.com", "example.com"))
+@pytest.mark.parametrize("host", ("https://example.com", "example.com"))
 def test_host(temp_config, networks, host):
     data = {"foundry": {"host": host}}
     with temp_config(data):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -231,8 +231,9 @@ def test_revert_error_using_impersonated_account(error_contract, accounts, conne
         error_contract.withdraw(sender=acct)
 
 
-def test_host(temp_config, networks):
-    data = {"foundry": {"host": "https://example.com"}}
+@pytest.mark.parameterize("host", ("https://example.com", "example.com"))
+def test_host(temp_config, networks, host):
+    data = {"foundry": {"host": host}}
     with temp_config(data):
         provider = networks.ethereum.local.get_provider("foundry")
         assert provider.uri == "https://example.com"


### PR DESCRIPTION
### What I did
 Noticed that remote node `uri` did not connect to the right port if it did not begin with `http` or `https` so made sure that it would still work if it was missing in the `config`. 
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it
Set the host in the `ape-config.yaml` in one project and check the `network.provider.uri` in the ape console. Then go into a second project with the same config and check to see that the ape console can connect to the first. 
### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
