### PR TITLE
feat: mining config options like block time auto-mine [APE-1175]

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,13 @@ from ape import chain
 anvil = chain.provider
 anvil.auto_mine = False  # calls `anvil_setAutomine` RPC.
 ```
+
+### Mine on an interval
+
+By default, Anvil will mine a new block every time a transaction is submitted.
+To mine on an interval instead, set the `block_time` config:
+
+```yaml
+foundry:
+  block_time: 10  # mine a new block every 10 seconds
+```

--- a/README.md
+++ b/README.md
@@ -134,3 +134,22 @@ foundry:
   base_fee: 0
   priority_fee: 0
 ```
+
+# Auto-mining
+
+Anvil nodes by default auto-mine.
+However, you can disable auto-mining on startup by configuring the foundry plugin like so:
+
+```yaml
+foundry:
+  auto_mine: false
+```
+
+Else, you can disable auto-mining using the provider instance:
+
+```python
+from ape import chain
+
+anvil = chain.provider
+anvil.auto_mine = False  # calls `anvil_setAutomine` RPC.
+```

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -102,6 +102,12 @@ class FoundryNetworkConfig(PluginConfig):
     Automatically mine blocks instead of manually doing so.
     """
 
+    block_time: Optional[int] = None
+    """
+    Set a block time to allow mining to happen on an interval
+    rather than only when a new transaction is submitted.
+    """
+
     class Config:
         extra = "allow"
 
@@ -411,6 +417,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
         if not self.config.auto_mine:
             cmd.append("--no-mining")
+
+        if self.config.block_time is not None:
+            cmd.extend(("--block-time", f"{self.config.block_time}"))
 
         return cmd
 

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -97,6 +97,11 @@ class FoundryNetworkConfig(PluginConfig):
     # Mapping of ecosystem_name => network_name => FoundryForkConfig
     fork: Dict[str, Dict[str, FoundryForkConfig]] = {}
 
+    auto_mine: bool = True
+    """
+    Automatically mine blocks instead of manually doing so.
+    """
+
     class Config:
         extra = "allow"
 
@@ -389,7 +394,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         super().disconnect()
 
     def build_command(self) -> List[str]:
-        return [
+        cmd = [
             self.anvil_bin,
             "--port",
             f"{self._port or DEFAULT_PORT}",
@@ -403,6 +408,11 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             "--block-base-fee-per-gas",
             f"{self.config.base_fee}",
         ]
+
+        if not self.config.auto_mine:
+            cmd.append("--no-mining")
+
+        return cmd
 
     def set_balance(self, account: AddressType, amount: Union[int, float, str, bytes]):
         is_str = isinstance(amount, str)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -274,3 +274,12 @@ def test_get_virtual_machine_error_from_contract_logic_message_includes_base_err
     actual = connected_provider.get_virtual_machine_error(exception)
     assert isinstance(actual, ContractLogicError)
     assert actual.base_err == exception
+
+
+def test_no_mining(temp_config, networks, connected_provider):
+    assert "--no-mining" not in connected_provider.build_command()
+    data = {"foundry": {"auto_mine": "false"}}
+    with temp_config(data):
+        provider = networks.ethereum.local.get_provider("foundry")
+        cmd = provider.build_command()
+        assert "--no-mining" in cmd

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -283,3 +283,13 @@ def test_no_mining(temp_config, networks, connected_provider):
         provider = networks.ethereum.local.get_provider("foundry")
         cmd = provider.build_command()
         assert "--no-mining" in cmd
+
+
+def test_block_time(temp_config, networks, connected_provider):
+    assert "--block-time" not in connected_provider.build_command()
+    data = {"foundry": {"block_time": 10}}
+    with temp_config(data):
+        provider = networks.ethereum.local.get_provider("foundry")
+        cmd = provider.build_command()
+        assert "--block-time" in cmd
+        assert "10" in cmd


### PR DESCRIPTION
### What I did

adds config options `auto_mine` and `block_time` to allow controlling mining more of your node

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
