### PR TITLE
fix: base fee fix for remote host [APE-1196]

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -131,10 +131,6 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         return self._test_config.mnemonic
 
     @property
-    def base_fee(self) -> int:
-        return self.config.base_fee
-
-    @property
     def number_of_accounts(self) -> int:
         return self._test_config.number_of_accounts
 


### PR DESCRIPTION
### What I did

issue preventing base fee from being correct when connecting to a remote host

### How I did it

remove "perf"

### How to verify it

send txns on remote host and notice base fee is no longer 0 when it makes sense

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
