### PR TITLE
fix: pre-set source traceback on traced calls [APE-1325]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: check-yaml
 
@@ -10,24 +10,24 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.5.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-PyYAML, types-requests, types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.14
+    rev: 0.7.17
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter]

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -43,7 +43,11 @@ from eth_utils import add_0x_prefix, is_0x_prefixed, is_hex, to_hex
 from ethpm_types import HexBytes
 from evm_trace import CallType, ParityTraceList
 from evm_trace import TraceFrame as EvmTraceFrame
-from evm_trace import get_calltree_from_geth_trace, get_calltree_from_parity_trace, create_trace_frames
+from evm_trace import (
+    create_trace_frames,
+    get_calltree_from_geth_trace,
+    get_calltree_from_parity_trace,
+)
 from web3 import HTTPProvider, Web3
 from web3.exceptions import ContractCustomError
 from web3.exceptions import ContractLogicError as Web3ContractLogicError

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ extras_require = {
         "ape-polygon",  # For running polygon fork tests
     ],
     "lint": [
-        "black>=23.3.0,<24",  # auto-formatter and linter
-        "mypy>=0.991,<1",  # Static type analyzer
+        "black>=23.7.0,<24",  # auto-formatter and linter
+        "mypy>=1.5.1,<2",  # Static type analyzer
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed
         "types-PyYAML",  # Needed due to mypy typeshed
-        "flake8>=6.0.0,<7",  # Style linter
-        "isort>=5.10.1,<6",  # Import sorting linter
-        "mdformat>=0.7.16",  # Auto-formatter for markdown
+        "flake8>=6.0.1,<7",  # Style linter
+        "isort>=<5.10.1,<6",  # Import sorting linter
+        "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
     ],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
         "types-setuptools",  # Needed due to mypy typeshed
         "types-PyYAML",  # Needed due to mypy typeshed
         "flake8>=6.0.1,<7",  # Style linter
-        "isort>=<5.10.1,<6",  # Import sorting linter
+        "isort>=5.10.1,<6",  # Import sorting linter
         "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -195,7 +195,7 @@ def test_set_code(connected_provider, contract_container, owner):
     contract = contract_container.deploy(sender=owner)
     provider = connected_provider
     code = provider.get_code(contract.address)
-    assert type(code) == HexBytes
+    assert type(code) is HexBytes
     assert provider.set_code(contract.address, "0x00") is True
     assert provider.get_code(contract.address) != code
     assert provider.set_code(contract.address, code) is True


### PR DESCRIPTION
### What I did

This helps dev messages, coverage, and anything needing source tracing to work better when failures occur on calls (view methods)

### How I did it

in error handling, try make the source tb and then set it.
Note, I had to do this in ape-geth to fix an issue with dev message detection so am copying the changes here.
Unable to test this very easily as it also requires ape-vyper. hmmmmm.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
