### PR TITLE
fix: detect paris and shanghai evm based on chain height [APE-1359]

### DIFF
--- a/ape_foundry/constants.py
+++ b/ape_foundry/constants.py
@@ -12,6 +12,8 @@ EVM_VERSION_BY_NETWORK = {
             9200000: "muirglacier",
             12244000: "berlin",
             12965000: "london",
+            15537394: "paris",
+            17034870: "shanghai",
         },
         "goerli": {
             0: "petersburg",


### PR DESCRIPTION
### What I did

took block numbers from here
https://github.com/ethereum/execution-specs

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
