### PR TITLE
refactor: use `anvil_mine` instead of `evm_mine`

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -492,9 +492,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         self._make_request("evm_setNextBlockTimestamp", [new_timestamp])
 
     def mine(self, num_blocks: int = 1):
-        result = self._make_request("evm_mine", [{"blocks": num_blocks, "timestamp": None}])
-        if result != "0x0":
-            raise FoundryProviderError(f"Failed to mine.\n{result}")
+        # NOTE: Request fails when given numbers with any left padded 0s.
+        num_blocks_arg = f"0x{HexBytes(num_blocks).hex().replace('0x', '').lstrip('0')}"
+        self._make_request("anvil_mine", [num_blocks_arg])
 
     def snapshot(self) -> str:
         return self._make_request("evm_snapshot", [])


### PR DESCRIPTION
### What I did

`anvil` finally added the `anvil_mine` method (mimicking [`hardhat_mine`](https://github.com/ApeWorX/ape-hardhat/blob/main/ape_hardhat/provider.py#L707C61-L707C61)) so I copy-pasted that implemention to `anvil` call

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
