### PR TITLE
fix: force type 0 transactions when using impersonated accounts

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -500,7 +500,10 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             sender = self.conversion_manager.convert(txn.sender, AddressType)
 
         if sender and sender in self.unlocked_accounts:
-            # Allow for an unsigned transaction
+            # Impersonated accounts must use type-0 to avoid unfair
+            # checks in Foundry.
+            txn.type = 0
+
             txn = self.prepare_transaction(txn)
             txn_dict = txn.model_dump(mode="json", by_alias=True)
             if isinstance(txn_dict.get("type"), int):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -107,8 +107,7 @@ def test_unlock_account(connected_provider, contract_a, accounts):
     assert isinstance(acct, ImpersonatedAccount)
 
     # Ensure can transact.
-    # NOTE: Using type 0 to avoid needing to set a balance.
-    receipt_0 = contract_a.methodWithoutArguments(sender=acct, type=0)
+    receipt_0 = contract_a.methodWithoutArguments(sender=acct)
     assert not receipt_0.failed
 
 


### PR DESCRIPTION
### What I did

Impersonated accounts dont work when they have no balance and are using type 2.
This forces type 0 to lessen confusion.

fixes: https://github.com/ApeWorX/ape/issues/1865

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
