### PR TITLE
feat: add support for Foundry keystore accounts

### DIFF
--- a/ape_foundry/__init__.py
+++ b/ape_foundry/__init__.py
@@ -15,6 +15,8 @@ from .provider import (
     FoundrySubprocessError,
 )
 
+from .accounts import FoundryAccount, AccountContainer
+
 
 @plugins.register(plugins.Config)
 def config_class():
@@ -51,6 +53,10 @@ def providers():
     yield "polygon", LOCAL_NETWORK_NAME, FoundryProvider
     yield "polygon", "mainnet-fork", FoundryForkProvider
     yield "polygon", "mumbai-fork", FoundryForkProvider
+
+@plugins.register(plugins.AccountPlugin)
+def account_types():
+    return AccountContainer, FoundryAccount
 
 
 __all__ = [

--- a/ape_foundry/accounts.py
+++ b/ape_foundry/accounts.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from ape.api import AccountAPI, AccountContainerAPI
+from ape_accounts.accounts import KeyfileAccount
+from ape.types import AddressType
+from eth_account import Account as EthAccount
+import os
+from typing import Iterator, Optional
+
+class AccountContainer(AccountContainerAPI):
+    """
+    A container for Foundry accounts. Foundry accounts are stored as keyfiles
+    and are identical to the ones ape uses, except they don't have a .json
+    extension and are stored in a different path.
+    """
+
+    accounts_dir: Path = Path.home() / ".foundry" / "keystores"
+
+    @property
+    def aliases(self) -> Iterator[str]:
+        return (p.stem for p in self.accounts_dir.glob("*"))
+
+    @property
+    def accounts(self) -> Iterator[AccountAPI]:
+        return (FoundryAccount(keyfile_path=p) for p in self.accounts_dir.glob("*"))
+
+    def __len__(self) -> int:
+        return len([*self.accounts_dir.glob("*")])
+
+
+class FoundryAccount(KeyfileAccount):
+
+    _address: Optional[AddressType] = None
+
+    @property
+    def address(self) -> AddressType:
+        # NOTE: Foundry uses standard Ethereum keystores which do not have an
+        #      address field. We need to compute the address from the private
+        #      key. Because this requires unlocking, we do two things:
+        #      - return cached value (or None) if locked, to allow easy iteration
+        #        over accounts without prompting for a password each time
+        #      - cache the address once computed, so we don't have to compute
+        #        it again, potentially requiring a password if the account
+        #        is re-locked
+        if self.locked:
+            return self._address # cached value or None
+        if self._address is None:
+            key = self._KeyfileAccount__key
+            account = EthAccount.from_key(key)
+            self._address = AddressType(account.address)
+        return self._address

--- a/ape_foundry/accounts.py
+++ b/ape_foundry/accounts.py
@@ -36,7 +36,7 @@ class FoundryAccount(KeyfileAccount):
         # NOTE: Foundry uses standard Ethereum keystores which do not have an
         #      address field. We need to compute the address from the private
         #      key. Because this requires unlocking, we do two things:
-        #      - return cached value (or None) if locked, to allow easy iteration
+        #      - return cached value (or placeholder) if locked, to allow easy iteration
         #        over accounts without prompting for a password each time
         #      - cache the address once computed, so we don't have to compute
         #        it again, potentially requiring a password if the account

--- a/ape_foundry/accounts.py
+++ b/ape_foundry/accounts.py
@@ -42,7 +42,7 @@ class FoundryAccount(KeyfileAccount):
         #        it again, potentially requiring a password if the account
         #        is re-locked
         if self.locked:
-            return self._address # cached value or None
+            return self._address or "*address encrypted*" # cached value or placeholder
         if self._address is None:
             key = self._KeyfileAccount__key
             account = EthAccount.from_key(key)


### PR DESCRIPTION
### What I did

Added support for [Foundry keystore accounts](https://book.getfoundry.sh/reference/cast/cast-wallet-list)
fixes: #

### How I did it

Implemented AccountsContainer and a child class of KeystoreAccount handling the differences between ape's keystores and foundry's.

The main difference is that Foundry keystores don't include the address so we have to compute that, which requires unlocking and getting the private key. We do some caching and sometimes return None to make things more convenient.

### How to verify it

After installing foundry, run:

`cast wallet new testwallet`

then after installing this plugin run:

`ape accounts list --all`

output should include:

```sh
Found 1 account in the 'foundry' plugin:
  *address encrypted* (alias: 'testwallet')
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
