### PR TITLE
feat: show call trace on transaction revert

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -730,7 +730,8 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
             # Show call trace if availble
             if enriched.txn:
-                # Apparently this is not always a receipt on a failed tx
+                # Unlikely scenario where a transaction is on the error even though a receipt
+                # exists.
                 if isinstance(enriched.txn, TransactionAPI) and enriched.txn.receipt:
                     enriched.txn.receipt.show_trace()
                 elif isinstance(enriched.txn, ReceiptAPI):


### PR DESCRIPTION
### What I did

Will show the call trace on transaction revert.

Ref: https://github.com/ApeWorX/ape/issues/1945

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [X] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
