### PR TITLE
refactor: remove goerli

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: check-yaml
 
 -   repo: https://github.com/PyCQA/isort
-    rev: v5.13.2
+    rev: 5.13.2
     hooks:
       - id: isort
 

--- a/ape_foundry/__init__.py
+++ b/ape_foundry/__init__.py
@@ -50,7 +50,7 @@ def providers():
 
     yield "polygon", LOCAL_NETWORK_NAME, FoundryProvider
     yield "polygon", "mainnet-fork", FoundryForkProvider
-    yield "polygon", "mumbai-fork", FoundryForkProvider
+    yield "polygon", "amoy-fork", FoundryForkProvider
 
     yield "base", LOCAL_NETWORK_NAME, FoundryProvider
     yield "base", "mainnet-fork", FoundryForkProvider

--- a/ape_foundry/__init__.py
+++ b/ape_foundry/__init__.py
@@ -31,8 +31,6 @@ def providers():
     yield "arbitrum", LOCAL_NETWORK_NAME, FoundryProvider
     yield "arbitrum", "mainnet-fork", FoundryForkProvider
     yield "arbitrum", "sepolia-fork", FoundryForkProvider
-    # TODO: Remove when goerli is sunset
-    yield "arbitrum", "goerli-fork", FoundryForkProvider
 
     yield "avalanche", LOCAL_NETWORK_NAME, FoundryProvider
     yield "avalanche", "mainnet-fork", FoundryForkProvider
@@ -49,8 +47,6 @@ def providers():
     yield "optimism", LOCAL_NETWORK_NAME, FoundryProvider
     yield "optimism", "mainnet-fork", FoundryForkProvider
     yield "optimism", "sepolia-fork", FoundryForkProvider
-    # TODO: Remove when goerli is sunset
-    yield "optimism", "goerli-fork", FoundryForkProvider
 
     yield "polygon", LOCAL_NETWORK_NAME, FoundryProvider
     yield "polygon", "mainnet-fork", FoundryForkProvider
@@ -58,7 +54,6 @@ def providers():
 
     yield "base", LOCAL_NETWORK_NAME, FoundryProvider
     yield "base", "mainnet-fork", FoundryForkProvider
-    yield "base", "goerli-fork", FoundryForkProvider
     yield "base", "sepolia-fork", FoundryForkProvider
 
     yield "blast", LOCAL_NETWORK_NAME, FoundryProvider

--- a/ape_foundry/constants.py
+++ b/ape_foundry/constants.py
@@ -24,11 +24,9 @@ EVM_VERSION_BY_NETWORK = {
             14750000: "berlin",
             23850000: "london",
         },
-        "mumbai": {
-            0: "petersburg",
-            2722000: "muirglacier",
-            13996000: "berlin",
-            22640000: "london",
+        "amoy": {
+            0: "berlin",
+            73100: "london",
         },
     },
 }

--- a/ape_foundry/constants.py
+++ b/ape_foundry/constants.py
@@ -13,11 +13,8 @@ EVM_VERSION_BY_NETWORK = {
             12244000: "berlin",
             12965000: "london",
         },
-        "goerli": {
-            0: "petersburg",
-            1561651: "istanbul",
-            4460644: "berlin",
-            5062605: "london",
+        "sepolia": {
+            0: "london",
         },
     },
     "polygon": {

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from setuptools import find_packages, setup
 

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -25,9 +25,6 @@ foundry:
       mainnet:
         upstream_provider: alchemy
         block_number: 15776634
-      goerli:
-        upstream_provider: alchemy
-        block_number: 7849922
       sepolia:
         upstream_provider: alchemy
         block_number: 3091950

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -9,7 +9,7 @@ ethereum:
 polygon:
   local:
     default_provider: foundry
-  mumbai:
+  amoy:
     default_provider: alchemy
   mainnet:
     default_provider: alchemy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,8 +246,9 @@ def sepolia_fork_provider(name, ethereum, sepolia_fork_port):
 def temp_config(config):
     @contextmanager
     def func(data: Dict, package_json: Optional[Dict] = None):
+        # TODO: Use `ape.utils.use_tempdir()` (once released)
         with tempfile.TemporaryDirectory() as temp_dir_str:
-            temp_dir = Path(temp_dir_str)
+            temp_dir = Path(temp_dir_str).resolve()
 
             config._cached_configs = {}
             config_file = temp_dir / CONFIG_FILE_NAME

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ NAME = "foundry"
 # Needed to test tracing support in core `ape test` command.
 pytest_plugins = ["pytester"]
 MAINNET_FORK_PORT = 9001
-GOERLI_FORK_PORT = 9002
+SEPOLIA_FORK_PORT = 9002
 
 
 def pytest_runtest_makereport(item, call):
@@ -230,14 +230,14 @@ def mainnet_fork_provider(name, mainnet_fork, mainnet_fork_port):
 
 
 @pytest.fixture
-def goerli_fork_port():
-    return GOERLI_FORK_PORT
+def sepolia_fork_port():
+    return SEPOLIA_FORK_PORT
 
 
 @pytest.fixture
-def goerli_fork_provider(name, ethereum, goerli_fork_port):
-    with ethereum.goerli_fork.use_provider(
-        name, provider_settings={"host": f"http://127.0.0.1:{goerli_fork_port}"}
+def sepolia_fork_provider(name, ethereum, sepolia_fork_port):
+    with ethereum.sepolia_fork.use_provider(
+        name, provider_settings={"host": f"http://127.0.0.1:{sepolia_fork_port}"}
     ) as provider:
         yield provider
 

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -173,13 +173,13 @@ def test_connect_to_polygon(networks, owner, contract_container):
     """
     Ensures we don't get PoA middleware issue.
     """
-    with networks.polygon.mumbai_fork.use_provider("foundry"):
+    with networks.polygon.amoy_fork.use_provider("foundry"):
         contract = owner.deploy(contract_container)
         assert isinstance(contract, ContractInstance)  # Didn't fail
 
 
 @pytest.mark.fork
-@pytest.mark.parametrize("network,port", [("mumbai", 9878), ("mainnet", 9879)])
+@pytest.mark.parametrize("network,port", [("amoy", 9878), ("mainnet", 9879)])
 def test_provider_settings(networks, network, port):
     expected_block_number = 1234
     settings = {

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -18,7 +18,7 @@ def mainnet_fork_contract_instance(owner, contract_container, mainnet_fork_provi
 
 @pytest.mark.fork
 def test_multiple_providers(
-    name, networks, ethereum, connected_provider, mainnet_fork_port, goerli_fork_port
+    name, networks, ethereum, connected_provider, mainnet_fork_port, sepolia_fork_port
 ):
     default_host = "http://127.0.0.1:8545"
     assert networks.active_provider.name == name
@@ -30,12 +30,14 @@ def test_multiple_providers(
         assert networks.active_provider.name == name
         assert networks.active_provider.network.name == "mainnet-fork"
         assert networks.active_provider.uri == mainnet_fork_host
-        goerli_fork_host = f"http://127.0.0.1:{goerli_fork_port}"
+        sepolia_fork_host = f"http://127.0.0.1:{sepolia_fork_port}"
 
-        with ethereum.goerli_fork.use_provider(name, provider_settings={"host": goerli_fork_host}):
+        with ethereum.sepolia_fork.use_provider(
+            name, provider_settings={"host": sepolia_fork_host}
+        ):
             assert networks.active_provider.name == name
-            assert networks.active_provider.network.name == "goerli-fork"
-            assert networks.active_provider.uri == goerli_fork_host
+            assert networks.active_provider.network.name == "sepolia-fork"
+            assert networks.active_provider.uri == sepolia_fork_host
 
         assert networks.active_provider.name == name
         assert networks.active_provider.network.name == "mainnet-fork"
@@ -55,7 +57,7 @@ def test_fork_config(name, config, network):
 
 
 @pytest.mark.fork
-def test_goerli_impersonate(accounts, goerli_fork_provider):
+def test_sepolia_impersonate(accounts, sepolia_fork_provider):
     impersonated_account = accounts[TEST_ADDRESS]
     other_account = accounts[0]
     receipt = impersonated_account.transfer(other_account, "1 wei")
@@ -86,21 +88,21 @@ def test_request_timeout(networks, config, mainnet_fork_provider):
 
 
 @pytest.mark.fork
-def test_reset_fork_no_fork_block_number(goerli_fork_provider):
-    goerli_fork_provider.mine(5)
-    prev_block_num = goerli_fork_provider.get_block("latest").number
-    goerli_fork_provider.reset_fork()
-    block_num_after_reset = goerli_fork_provider.get_block("latest").number
+def test_reset_fork_no_fork_block_number(sepolia_fork_provider):
+    sepolia_fork_provider.mine(5)
+    prev_block_num = sepolia_fork_provider.get_block("latest").number
+    sepolia_fork_provider.reset_fork()
+    block_num_after_reset = sepolia_fork_provider.get_block("latest").number
     assert block_num_after_reset < prev_block_num
 
 
 @pytest.mark.fork
-def test_reset_fork_specify_block_number_via_argument(goerli_fork_provider):
-    goerli_fork_provider.mine(5)
-    prev_block_num = goerli_fork_provider.get_block("latest").number
+def test_reset_fork_specify_block_number_via_argument(sepolia_fork_provider):
+    sepolia_fork_provider.mine(5)
+    prev_block_num = sepolia_fork_provider.get_block("latest").number
     new_block_number = prev_block_num - 1
-    goerli_fork_provider.reset_fork(block_number=new_block_number)
-    block_num_after_reset = goerli_fork_provider.get_block("latest").number
+    sepolia_fork_provider.reset_fork(block_number=new_block_number)
+    block_num_after_reset = sepolia_fork_provider.get_block("latest").number
     assert block_num_after_reset == new_block_number
 
 

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -48,7 +48,8 @@ def test_multiple_providers(
     assert networks.active_provider.uri == default_host
 
 
-@pytest.mark.parametrize("network", [k for k in NETWORKS.keys()])
+# TODO: Remove `in` check once goerli removed from core.
+@pytest.mark.parametrize("network", [k for k in NETWORKS.keys() if k not in ("goerli",)])
 def test_fork_config(name, config, network):
     plugin_config = config.get_config(name)
     network_config = plugin_config["fork"].get("ethereum", {}).get(network, {})
@@ -60,6 +61,7 @@ def test_fork_config(name, config, network):
 def test_sepolia_impersonate(accounts, sepolia_fork_provider):
     impersonated_account = accounts[TEST_ADDRESS]
     other_account = accounts[0]
+    impersonated_account.balance += 1_000_000_000_000_000_000
     receipt = impersonated_account.transfer(other_account, "1 wei")
     assert receipt.receiver == other_account
     assert receipt.sender == impersonated_account
@@ -69,6 +71,7 @@ def test_sepolia_impersonate(accounts, sepolia_fork_provider):
 def test_mainnet_impersonate(accounts, mainnet_fork_provider):
     impersonated_account = accounts[TEST_ADDRESS]
     other_account = accounts[0]
+    impersonated_account.balance += 1_000_000_000_000_000_000
     receipt = impersonated_account.transfer(other_account, "1 wei")
     assert receipt.receiver == other_account
     assert receipt.sender == impersonated_account
@@ -81,8 +84,9 @@ def test_request_timeout(networks, config, mainnet_fork_provider):
     assert actual == expected
 
     # Test default behavior
+    # TODO: Use `ape.utils.use_tempdir()` (once released)
     with tempfile.TemporaryDirectory() as temp_dir_str:
-        temp_dir = Path(temp_dir_str)
+        temp_dir = Path(temp_dir_str).resolve()
         with config.using_project(temp_dir):
             assert networks.active_provider.timeout == 300
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -159,8 +159,9 @@ def test_request_timeout(connected_provider, config):
     assert actual == expected
 
     # Test default behavior
+    # TODO: Use `ape.utils.use_tempdir()` (once released)
     with tempfile.TemporaryDirectory() as temp_dir_str:
-        temp_dir = Path(temp_dir_str)
+        temp_dir = Path(temp_dir_str).resolve()
         with config.using_project(temp_dir):
             assert connected_provider.timeout == 30
 

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -62,9 +62,10 @@ def test_local_transaction_traces(local_receipt, captrace):
     # NOTE: Strange bug in Rich where we can't use sys.stdout for testing tree output.
     # And we have to write to a file, close it, and then re-open it to see output.
     def run_test():
+        # TODO: Use `ape.utils.use_tempdir()` (once released)
         with tempfile.TemporaryDirectory() as temp_dir:
             # Use a tempfile to avoid terminal inconsistencies affecting output.
-            file_path = Path(temp_dir) / "temp"
+            file_path = Path(temp_dir).resolve() / "temp"
             with open(file_path, "w") as file:
                 local_receipt.show_trace(file=file)
 
@@ -80,8 +81,9 @@ def test_local_transaction_traces(local_receipt, captrace):
 
 def test_local_transaction_gas_report(local_receipt, captrace):
     def run_test():
+        # TODO: Use `ape.utils.use_tempdir()` (once released)
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_file = Path(temp_dir) / "temp"
+            temp_file = Path(temp_dir).resolve() / "temp"
             with open(temp_file, "w") as file:
                 local_receipt.show_gas_report(file=file)
 
@@ -98,8 +100,9 @@ def test_local_transaction_gas_report(local_receipt, captrace):
 
 @pytest.mark.manual
 def test_mainnet_transaction_traces(mainnet_receipt, captrace):
+    # TODO: Use `ape.utils.use_tempdir()` (once released)
     with tempfile.TemporaryDirectory() as temp_dir:
-        temp_file = Path(temp_dir) / "temp"
+        temp_file = Path(temp_dir).resolve() / "temp"
 
         with open(temp_file, "w") as file:
             mainnet_receipt.show_trace(file=file)


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

https://github.com/ledgerwatch/erigon/blob/devel/params/chainspecs/sepolia.json

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
