### PR TITLE
fix: allow empty fork cfg

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -43,7 +43,7 @@ from eth_utils import add_0x_prefix, is_0x_prefixed, is_hex, to_hex
 from evm_trace import CallType, ParityTraceList
 from evm_trace import TraceFrame as EvmTraceFrame
 from evm_trace import get_calltree_from_geth_trace, get_calltree_from_parity_trace
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import SettingsConfigDict
 from web3 import HTTPProvider, Web3
 from web3.exceptions import ContractCustomError
@@ -96,10 +96,10 @@ class FoundryNetworkConfig(PluginConfig):
     # Mapping of ecosystem_name => network_name => FoundryForkConfig
     fork: Dict[str, Dict[str, FoundryForkConfig]] = {}
 
+    disable_block_gas_limit: bool = False
     """
     Disable the ``call.gas_limit <= block.gas_limit`` constraint.
     """
-    disable_block_gas_limit: bool = False
 
     auto_mine: bool = True
     """
@@ -111,7 +111,13 @@ class FoundryNetworkConfig(PluginConfig):
     Set a block time to allow mining to happen on an interval
     rather than only when a new transaction is submitted.
     """
+
     model_config = SettingsConfigDict(extra="allow")
+
+    @field_validator("fork", mode="before")
+    @classmethod
+    def _validate_fork(cls, value):
+        return value or {}
 
 
 def _call(*args):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -14,7 +14,7 @@ from evm_trace import CallType
 from hexbytes import HexBytes
 
 from ape_foundry import FoundryProviderError
-from ape_foundry.provider import FOUNDRY_CHAIN_ID, _extract_custom_error
+from ape_foundry.provider import FOUNDRY_CHAIN_ID, FoundryNetworkConfig, _extract_custom_error
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
 
@@ -489,3 +489,8 @@ def test_extract_custom_error_transaction_given_trace_fails(mocker, tx_hash):
 
     # Show failure was tracked
     assert tracker[0] == HexBytes(tx.txn_hash).hex()
+
+
+def test_fork_config_none():
+    cfg = FoundryNetworkConfig.model_validate({"fork": None})
+    assert isinstance(cfg["fork"], dict)


### PR DESCRIPTION
### What I did

i had a config like:

```yaml
foundry:
  fork:
#    ethereum:
#      mainnet:
#        upstream_provider: geth
```

which turned to `None` and broke.
this fixes it

### How I did it

default to empty dict when none

### How to verify it

example cfg

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
