### PR TITLE
feat: honor `balance` test config value

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -39,3 +39,5 @@ test:
   gas:
     exclude:
       - method_name: setAdd*
+
+  balance: 100_000 ETH

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -132,6 +132,14 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         return self._test_config.number_of_accounts
 
     @property
+    def initial_balance(self) -> int:
+        """
+        Have to convert the WEI value to ETH, like Anvil expects.
+        """
+        bal_in_wei = self._test_config.balance
+        return bal_in_wei // 10**18
+
+    @property
     def process_name(self) -> str:
         return "anvil"
 
@@ -421,6 +429,8 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             f"{self.number_of_accounts}",
             "--derivation-path",
             f"{self.test_config.hd_path}",
+            "--balance",
+            f"{self.initial_balance}",
             "--steps-tracing",
             "--block-base-fee-per-gas",
             f"{self.settings.base_fee}",

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     url="https://github.com/ApeWorX/ape-foundry",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.8.1,<0.9",
+        "eth-ape>=0.8.9,<0.9",
         "ethpm-types",  # Use same version as eth-ape
         "eth-pydantic-types",  # Use same version as eth-ape
         "evm-trace",  # Use same version as ape

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -6,6 +6,8 @@ from ape.contracts import ContractInstance
 from ape.exceptions import ContractLogicError
 from ape_ethereum.ecosystem import NETWORKS
 
+from ape_foundry import FoundryNetworkConfig
+
 TESTS_DIRECTORY = Path(__file__).parent
 TEST_ADDRESS = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
 
@@ -224,3 +226,8 @@ def test_contract_interaction(mainnet_fork_provider, owner, mainnet_fork_contrac
 
     # Verify the estimate gas RPC was not used (since we are using max_gas).
     assert estimate_gas_spy.call_count == 0
+
+
+def test_fork_config_none():
+    cfg = FoundryNetworkConfig.model_validate({"fork": None})
+    assert isinstance(cfg["fork"], dict)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from ape import convert
 from ape.api import TraceAPI
 from ape.api.accounts import ImpersonatedAccount
 from ape.contracts import ContractContainer
@@ -13,7 +14,7 @@ from evm_trace import CallType
 from hexbytes import HexBytes
 
 from ape_foundry import FoundryProviderError
-from ape_foundry.provider import FOUNDRY_CHAIN_ID, FoundryNetworkConfig
+from ape_foundry.provider import FOUNDRY_CHAIN_ID
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
 
@@ -445,6 +446,9 @@ def test_disable_block_gas_limit(project, disconnected_provider):
         assert "--disable-block-gas-limit" in cmd
 
 
-def test_fork_config_none():
-    cfg = FoundryNetworkConfig.model_validate({"fork": None})
-    assert isinstance(cfg["fork"], dict)
+def test_initial_balance(accounts):
+    # The value is set in the config, but checking it can be less just in case.
+    # The regular default value is 10_000 so hopefully it isn't below that,
+    # just showing we were able to increase it.
+    acct = accounts[9]
+    assert convert("10_000 ETH", int) < acct.balance <= convert("100_000 ETH", int)


### PR DESCRIPTION
### What I did

support and honor the `--balance` flag via test config balance, requires this PR: https://github.com/ApeWorX/ape/pull/2173

### How I did it

set the initial balance from the value from the config, behaves like other testing providers.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
