### PR TITLE
feat: support `raise_on_revert` flag for calls and transactions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.11.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-PyYAML, types-requests, types-setuptools, pydantic]

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ extras_require = {
     ],
     "lint": [
         "black>=24.4.2,<25",  # Auto-formatter and linter
-        "mypy>=1.10.0,<2",  # Static type analyzer
+        "mypy>=1.11.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
         "types-requests",  # Needed for mypy type shed
         "types-PyYAML",  # Needed for mypy type shed
-        "flake8>=7.0.0,<8",  # Style linter
+        "flake8>=7.1.0,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
         "isort>=5.13.2,<6",  # Import sorting linter

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     url="https://github.com/ApeWorX/ape-foundry",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.8.9,<0.9",
+        "eth-ape>=0.8.10,<0.9",
         "ethpm-types",  # Use same version as eth-ape
         "eth-pydantic-types",  # Use same version as eth-ape
         "evm-trace",  # Use same version as ape

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -269,6 +269,16 @@ def test_revert_error_using_impersonated_account(error_contract, accounts, conne
         error_contract.withdraw(sender=acct)
 
 
+def test_revert_allow(error_contract, not_owner, contract_instance):
+    # 'sender' is not the owner so it will revert (with a message)
+    receipt = error_contract.withdraw(sender=not_owner, raise_on_revert=False)
+    assert receipt.error is not None
+    assert isinstance(receipt.error, error_contract.Unauthorized)
+
+    # Ensure this also works for calls.
+    contract_instance.setNumber.call(5, raise_on_revert=False)
+
+
 @pytest.mark.parametrize("host", ("https://example.com", "example.com"))
 def test_host(project, local_network, host):
     with project.temp_config(foundry={"host": host}):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -268,6 +268,11 @@ def test_revert_error_using_impersonated_account(error_contract, accounts, conne
     with pytest.raises(error_contract.Unauthorized):
         error_contract.withdraw(sender=acct)
 
+    # Show we can "allow" reverts using impersonated accounts.
+    # NOTE: This is extra because of the lack of tx-hash available.
+    receipt = error_contract.withdraw(sender=acct, raise_on_revert=False)
+    assert receipt.failed
+
 
 def test_revert_allow(error_contract, not_owner, contract_instance):
     # 'sender' is not the owner so it will revert (with a message)


### PR DESCRIPTION
### What I did

same as https://github.com/ApeWorX/ape/pull/2181

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
