### PR TITLE
feat: allow setting `evm-version` in local network

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ foundry:
   priority_fee: 0
 ```
 
-# Auto-mining
+## Auto-mining
 
 Anvil nodes by default auto-mine.
 However, you can disable auto-mining on startup by configuring the foundry plugin like so:
@@ -168,4 +168,23 @@ To mine on an interval instead, set the `block_time` config:
 ```yaml
 foundry:
   block_time: 10  # mine a new block every 10 seconds
+```
+
+## EVM Version (hardfork)
+
+To change the EVM version for local foundry networks, use the `evm_version` config:
+
+```yaml
+foundry:
+  evm_version: shanghai
+```
+
+To change the EVM version for forked networks, set it the specific forked-network config(s):
+
+```yaml
+foundry:
+  fork:
+    ethereum:
+      mainnet:
+        evm_version: shanghai
 ```

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -70,6 +70,9 @@ class FoundryNetworkConfig(PluginConfig):
     Defaults to ``True``. If ``host`` is remote, will not be able to start.
     """
 
+    evm_version: Optional[str] = None
+    """The EVM hardfork to use, e.g. `shanghai`."""
+
     # Retry strategy configs, try increasing these if you're getting FoundrySubprocessError
     request_timeout: int = 30
     fork_request_timeout: int = 300
@@ -419,6 +422,15 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         super().disconnect()
 
     def build_command(self) -> list[str]:
+        cmd = self._build_command()
+
+        if evm_version := self.settings.evm_version:
+            cmd.extend(("--hardfork", evm_version))
+
+        return cmd
+
+    def _build_command(self) -> list[str]:
+        # All shared between forks and local.
         cmd = [
             self.anvil_bin,
             "--port",

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -467,3 +467,12 @@ def test_initial_balance(accounts):
     # just showing we were able to increase it.
     acct = accounts[9]
     assert convert("10_000 ETH", int) < acct.balance <= convert("100_000 ETH", int)
+
+
+@pytest.mark.parametrize("host", ("https://example.com", "example.com"))
+def test_evm_version(project, local_network, host):
+    with project.temp_config(foundry={"evm_version": "shanghai"}):
+        provider = local_network.get_provider("foundry")
+        cmd = provider.build_command()
+        assert "--hardfork" in cmd
+        assert "shanghai" in cmd


### PR DESCRIPTION
### What I did

somehow this was missing! it was on forks but not the regular local one.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
