### PR TITLE
feat: set --optimism flag for optimism-based networks

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -447,6 +447,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         if self.settings.disable_block_gas_limit:
             cmd.append("--disable-block-gas-limit")
 
+        if self.network.ecosystem.name in ("optimism", "base"):
+            cmd.append("--optimism")
+
         return cmd
 
     def set_balance(self, account: AddressType, amount: Union[int, float, str, bytes]):

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "ape-alchemy",  # For running fork tests
         "ape-polygon",  # For running polygon fork tests
+        "ape-optimism",  # For Optimism integration tests
     ],
     "lint": [
         "black>=24.4.2,<25",  # Auto-formatter and linter

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -467,3 +467,12 @@ def test_initial_balance(accounts):
     # just showing we were able to increase it.
     acct = accounts[9]
     assert convert("10_000 ETH", int) < acct.balance <= convert("100_000 ETH", int)
+
+
+def test_optimism(networks):
+    with networks.optimism.local.use_provider(
+        "foundry", provider_settings={"port": 9545}
+    ) as provider:
+        assert provider.is_connected
+        cmd = provider.build_command()
+        assert "--optimism" in cmd


### PR DESCRIPTION
### What I did

when using optimism-based networks, add the --optimism flag

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
