### PR TITLE
feat: set --optimism flag for optimism-based networks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     rev: 7.1.0
     hooks:
     -   id: flake8
+        additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.0

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -178,6 +178,14 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             return self.uri
 
     @property
+    def use_optimism(self) -> bool:
+        return self.settings.use_optimism or (
+            self.settings.use_optimism is not False
+            and Optimism is not None
+            and isinstance(self.network.ecosystem, Optimism)
+        )
+
+    @property
     def _port(self) -> Optional[int]:
         return URL(self.uri).port
 
@@ -474,12 +482,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
         # Optimism-based networks are different; Anvil provides a flag to make
         # testing more like the real network(s).
-        if self.settings.use_optimism or (
-            Optimism is not None
-            and isinstance(
-                self.network.ecosystem, Optimism and self.settings.use_optimism is not False
-            )
-        ):
+        if self.use_optimism:
             cmd.append("--optimism")
 
         return cmd

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -45,8 +45,16 @@ from web3.types import TxParams
 from yarl import URL
 
 from ape_foundry.constants import EVM_VERSION_BY_NETWORK
+from ape_foundry.exceptions import (
+    FoundryNotInstalledError,
+    FoundryProviderError,
+    FoundrySubprocessError,
+)
 
-from .exceptions import FoundryNotInstalledError, FoundryProviderError, FoundrySubprocessError
+try:
+    from ape_optimism import Optimism
+except ImportError:
+    Optimism = None
 
 EPHEMERAL_PORTS_START = 49152
 EPHEMERAL_PORTS_END = 60999
@@ -102,6 +110,13 @@ class FoundryNetworkConfig(PluginConfig):
     """
     Set a block time to allow mining to happen on an interval
     rather than only when a new transaction is submitted.
+    """
+
+    use_optimism: Optional[bool] = None
+    """
+    Configure the node to run with the `--optimism` flag.
+    NOTE: When using Optimism-based networks (including Base),
+    this flag is automatically added.
     """
 
     model_config = SettingsConfigDict(extra="allow")
@@ -457,7 +472,14 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         if evm_version := self.evm_version:
             cmd.extend(("--hardfork", evm_version))
 
-        if self.network.ecosystem.name in ("optimism", "base"):
+        # Optimism-based networks are different; Anvil provides a flag to make
+        # testing more like the real network(s).
+        if self.settings.use_optimism or (
+            Optimism is not None
+            and isinstance(
+                self.network.ecosystem, Optimism and self.settings.use_optimism is not False
+            )
+        ):
             cmd.append("--optimism")
 
         return cmd

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -457,6 +457,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         if evm_version := self.evm_version:
             cmd.extend(("--hardfork", evm_version))
 
+        if self.network.ecosystem.name in ("optimism", "base"):
+            cmd.append("--optimism")
+
         return cmd
 
     def set_balance(self, account: AddressType, amount: Union[int, float, str, bytes]):

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -52,9 +52,9 @@ from ape_foundry.exceptions import (
 )
 
 try:
-    from ape_optimism import Optimism
+    from ape_optimism import Optimism  # type: ignore
 except ImportError:
-    Optimism = None
+    Optimism = None  # type: ignore
 
 EPHEMERAL_PORTS_START = 49152
 EPHEMERAL_PORTS_END = 60999

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ exclude =
 	venv*
 	docs
 	build
+ignore = E704,W503,PYD002
 per-file-ignores =
     # The traces have to be formatted this way for the tests.
     tests/expected_traces.py: E501

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
         "ape-alchemy",  # For running fork tests
         "ape-polygon",  # For running polygon fork tests
+        "ape-optimism",  # For Optimism integration tests
     ],
     "lint": [
         "black>=24.4.2,<25",  # Auto-formatter and linter

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ extras_require = {
         "flake8>=7.1.0,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
+        "flake8-pydantic",  # For detecting issues with Pydantic models
         "isort>=5.13.2,<6",  # Import sorting linter
         "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -483,3 +483,12 @@ def test_evm_version(project, local_network, host):
         cmd = provider.build_command()
         assert "--hardfork" in cmd
         assert "shanghai" in cmd
+
+
+def test_optimism(networks):
+    with networks.optimism.local.use_provider(
+        "foundry", provider_settings={"port": 9545}
+    ) as provider:
+        assert provider.is_connected
+        cmd = provider.build_command()
+        assert "--optimism" in cmd


### PR DESCRIPTION
### What I did

* feat: Add a config to set the `--optimism` flag (or turn it off in cases when we turn it on automatically)
* feat: when using Optimism based networks, automatically pass `--optimism` (unless specified not to)

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
