### PR TITLE
fix: some reverts tests were failing because of a sudden reverts prefix on error messages

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -607,6 +607,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         else:
             revert_message = revert_message or TransactionError.DEFAULT_MESSAGE
 
+        if revert_message.startswith("revert: "):
+            revert_message = revert_message[8:]
+
         # Create and enrich the error
         sub_err = ContractLogicError(base_err=exception, revert_message=revert_message, **kwargs)
         enriched = self.compiler_manager.enrich_error(sub_err)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from ape import convert
+from ape import convert, reverts
 from ape.api import TraceAPI
 from ape.api.accounts import ImpersonatedAccount
 from ape.contracts import ContractContainer
@@ -191,6 +191,10 @@ def test_revert(sender, contract_instance):
     # 'sender' is not the owner so it will revert (with a message)
     with pytest.raises(ContractLogicError, match="!authorized"):
         contract_instance.setNumber(6, sender=sender)
+
+    # Show it also works with the reverts-context-manager.
+    with reverts("!authorized"):
+        contract_instance.setNumber(55, sender=sender)
 
 
 def test_contract_revert_no_message(owner, contract_instance):


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
