### PR TITLE
fix: show trace on transaction fail

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
           with:
               fetch-depth: 0
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
 
         - name: Setup Python
           uses: actions/setup-python@v5

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,14 +26,11 @@ jobs:
             python -m pip install --upgrade pip
             pip install .[lint]
 
-        - name: Run Black
-          run: black --check .
+        - name: Run Ruff Lint
+          run: ruff check .
 
-        - name: Run isort
-          run: isort --check-only .
-
-        - name: Run flake8
-          run: flake8 .
+        - name: Run Ruff Format
+          run: ruff format --check .
 
         - name: Run mdformat
           run: mdformat . --check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
 
         - name: Setup Python
           uses: actions/setup-python@v5
@@ -42,7 +42,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
 
         - name: Setup Python
           uses: actions/setup-python@v5
@@ -66,7 +66,7 @@ jobs:
                 python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
 
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
 
         - name: Install Foundry
           uses: foundry-rs/foundry-toolchain@v1
@@ -102,7 +102,7 @@ jobs:
 #            fail-fast: true
 #
 #        steps:
-#        - uses: actions/checkout@v4
+#        - uses: actions/checkout@v5
 #
 #        - name: Setup Python
 #          uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,31 +4,21 @@ repos:
     hooks:
     -   id: check-yaml
 
--   repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.0  # Latest ruff version
     hooks:
-      - id: isort
-
--   repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
-        name: black
-
--   repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
-    hooks:
-    -   id: flake8
-        additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic, flake8-type-checking]
+    -   id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+    -   id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.16.1
     hooks:
     -   id: mypy
-        additional_dependencies: [types-PyYAML, types-requests, types-setuptools, pydantic]
+        additional_dependencies: [types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.19
+    rev: 0.7.22
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -26,16 +26,17 @@ from ape.logging import logger
 from ape.utils import cached_property
 from ape_ethereum.provider import Web3Provider
 from ape_test import ApeTestConfig
-from eth_pydantic_types import HexBytes, HexBytes32
 from eth_typing import HexStr
 from eth_utils import add_0x_prefix, is_0x_prefixed, is_hex, to_hex
 from pydantic import field_validator, model_validator
 from pydantic_settings import SettingsConfigDict
 from web3 import HTTPProvider, Web3
-from web3.exceptions import ContractCustomError
+from web3.exceptions import ContractCustomError, ExtraDataLengthError
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
-from web3.exceptions import ExtraDataLengthError
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
+
+from eth_pydantic_types import HexBytes, HexBytes32
+from eth_pydantic_types.utils import PadDirection
 
 try:
     from web3.middleware import ExtraDataToPOAMiddleware  # type: ignore
@@ -348,8 +349,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
                 else:
                     # The user configured a host and the anvil process was already running.
                     logger.info(
-                        f"Connecting to existing '{self.process_name}' "
-                        f"at host '{self._clean_uri}'."
+                        f"Connecting to existing '{self.process_name}' at host '{self._clean_uri}'."
                     )
             else:
                 for _ in range(self.settings.process_attempts):
@@ -628,7 +628,10 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
                     trace = txn.receipt.trace
                 else:
                     # Calls it from the provider.
-                    trace = txn.trace
+                    try:
+                        trace = txn.trace
+                    except Exception:
+                        pass
 
             elif isinstance(txn, ReceiptAPI):
                 trace = txn.trace
@@ -679,8 +682,8 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             "anvil_setStorageAt",
             [
                 address,
-                to_hex(HexBytes32.__eth_pydantic_validate__(slot)),
-                to_hex(HexBytes32.__eth_pydantic_validate__(value)),
+                to_hex(HexBytes32.__eth_pydantic_validate__(slot, pad=PadDirection.LEFT)),
+                to_hex(HexBytes32.__eth_pydantic_validate__(value, pad=PadDirection.LEFT)),
             ],
         )
 

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -604,6 +604,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
     def _handle_execution_reverted(  # type: ignore[override]
         self, exception: Exception, revert_message: Optional[str] = None, **kwargs
     ):
+        trace = kwargs.get("trace")
+        txn = kwargs.get("txn")
+
         # Assign default message if revert_message is invalid
         if revert_message == "0x":
             revert_message = TransactionError.DEFAULT_MESSAGE
@@ -618,12 +621,22 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         enriched = self.compiler_manager.enrich_error(sub_err)
 
         # Show call trace if available
-        txn = enriched.txn
-        if txn and hasattr(txn, "show_trace"):
-            if isinstance(txn, TransactionAPI) and txn.receipt:
-                txn.receipt.show_trace()
+        if trace and callable(trace):
+            trace = trace()
+
+        if not trace and (txn := txn):
+            if isinstance(txn, TransactionAPI):
+                if txn.receipt:
+                    trace = txn.receipt.trace
+                else:
+                    # Calls it from the provider.
+                    trace = txn.trace
+
             elif isinstance(txn, ReceiptAPI):
-                txn.show_trace()
+                trace = txn.trace
+
+        if trace:
+            trace.show()
 
         return enriched
 

--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -66,6 +66,9 @@ EPHEMERAL_PORTS_START = 49152
 EPHEMERAL_PORTS_END = 60999
 DEFAULT_PORT = 8545
 FOUNDRY_CHAIN_ID = 31337
+FOUNDRY_REVERT_PREFIX = (
+    "Error: VM Exception while processing transaction: reverted with reason string"
+)
 
 
 class FoundryForkConfig(PluginConfig):
@@ -354,7 +357,7 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
                         self._start()
                         break
                     except FoundryNotInstalledError:
-                        # Is a sub-class of `FoundrySubprocessError` but we to still raise
+                        # Is a subclass of `FoundrySubprocessError` but we to still raise
                         # so we don't keep retrying.
                         raise
                     except SubprocessError as exc:
@@ -562,14 +565,9 @@ class FoundryProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         if not message:
             return VirtualMachineError(base_err=exception, **kwargs)
 
-        # Handle specific cases based on message content
-        foundry_prefix = (
-            "Error: VM Exception while processing transaction: reverted with reason string "
-        )
-
         # Handle Foundry error prefix
-        if message.startswith(foundry_prefix):
-            message = message.replace(foundry_prefix, "").strip("'")
+        if message.startswith(FOUNDRY_REVERT_PREFIX):
+            message = message.replace(f"{FOUNDRY_REVERT_PREFIX} ", "").strip("'")
             return self._handle_execution_reverted(exception, message, **kwargs)
 
         # Handle various cases of transaction reverts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,40 +8,122 @@ plugins = ["pydantic.mypy"]
 [tool.setuptools_scm]
 write_to = "ape_foundry/version.py"
 
-# NOTE: you have to use single-quoted strings in TOML for regular expressions.
-# It's the equivalent of r-strings in Python.  Multiline strings are treated as
-# verbose regular expressions by Black.  Use [ ] to denote a significant space
-# character.
 
-[tool.black]
+[tool.ruff]
+target-version = "py39"
 line-length = 100
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
-include = '\.pyi?$'
 
-[tool.pytest.ini_options]
-addopts = """
-    -p no:ape_test
-    --cov-branch
-    --cov-report term
-    --cov-report html
-    --cov-report xml
-    --cov=ape_foundry
-"""
-python_files = "test_*.py"
-testpaths = "tests"
-markers = """
-fuzzing: Run Hypothesis fuzz test suite
-fork: Run forked-network tests using Alchemy as the upstream provider
-manual: Tests you want to avoid running in automated CI/CD because of expense
-"""
+[tool.ruff.lint]
+# Select rule categories to enforce
+select = [
+    # Core Python errors and style
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "W",    # pycodestyle warnings
+    "I",    # isort
+    "B",    # flake8-bugbear - common bugs/design issues
+    "C4",   # flake8-comprehensions - simplify comprehensions
+    "UP",   # pyupgrade - modern Python features/idioms
+    "RET",  # flake8-return - cleaner return statements
+    "SIM",  # flake8-simplify - code simplification
+    "S",    # flake8-bandit - security issues
+    "TCH",  # flake8-type-checking - type annotation improvements
+    "T10",  # flake8-debugger - detect debugger calls/imports
+    "FIX",  # flake8-fixme - detect FIXME, TODO, XXX comments
+]
 
-[tool.isort]
-line_length = 100
-force_grid_wrap = 0
-include_trailing_comma = true
-multi_line_output = 3
-use_parentheses = true
-skip = ["version.py"]
+# Rules to ignore
+ignore = [
+    "E501",
+
+    # Specific bugbear issues
+    "B904",     # Use 'raise from' in except blocks
+    "B006",     # Mutable default arguments
+    "B007",     # Loop control variable not used within loop body
+    "B012",     # Jump statements in finally blocks
+    "B028",     # No explicit stacklevel in warnings
+
+    # FIXME/TODO comments - these are intentional markers for future work
+    "FIX002",   # Line contains TODO
+    "FIX004",   # Line contains HACK
+
+    # Code structure preferences
+    "SIM102",   # Use a single if statement instead of nested if statements
+    "SIM105",   # Use contextlib.suppress instead of try-except-pass
+    "SIM108",   # Use ternary operator instead of if-else block
+    "SIM113",   # Use enumerate instead of manually incrementing counter
+    "SIM114",   # If branches with identical arm bodies (combine with or)
+    "SIM115",   # Use context manager for opening files
+    "SIM116",   # Use dictionary instead of if-statements
+    "SIM117",   # Multiple with statements
+    "B018",     # Useless expression
+
+    # Return statement style
+    "RET501",   # Do not explicitly return None
+    "RET502",   # Implicit return at the end of function able to return non-None value
+    "RET503",   # Missing explicit return at the end of function able to return non-None value
+    "RET504",   # Unnecessary assignment before return
+    "RET505",   # Unnecessary else after return
+    "RET506",   # Unnecessary else after raise
+    "RET507",   # Unnecessary else after continue
+    "RET508",   # Unnecessary else after break
+
+    # Security issues (allow common patterns in the codebase)
+    "S101",     # Use of assert (many asserts are used for type checking)
+    "S102",     # Use of exec (needed in some specific places)
+    "S105",     # Hardcoded password string
+    "S110",     # Try-except-pass (common pattern for handling optional features)
+    "S112",     # Try-except-continue
+    "S113",     # Request without timeout
+    "S202",     # Tarfile unsafe members
+    "S307",     # Use of eval
+    "S311",     # Suspicious non-cryptographic random usage
+    "S603",     # Subprocess without shell=True
+    "S607",     # Start process with partial path
+
+    # Style/readability issues (improve incrementally)
+    "C416",     # Unnecessary comprehension (rewrite using list/set/dict)
+    "C408",     # Unnecessary dict() call (rewrite as literal)
+    "C417",     # Unnecessary map usage (replace with generator)
+    "C414",     # Unnecessary list/dict call within another function
+    "C401",     # Unnecessary generator (rewrite as comprehension)
+    "C409",     # Unnecessary literal within tuple/list/dict call
+    "C419",     # Unnecessary comprehension in call
+    "SIM101",   # Duplicate isinstance call
+    "SIM103",   # Needless boolean conversion
+    "SIM110",   # Reimplemented builtin
+    "SIM118",   # Use 'key in dict' instead of 'key in dict.keys()'
+    "SIM401",   # Use dict.get instead of if-else block
+    "SIM910",   # Use dict.get(key) instead of dict.get(key, None)
+    "TC001",    # Move application import into type-checking block
+    "TC003",    # Move standard library import into type-checking block
+    "TC006",    # Add quotes to type expression in `typing.cast()`
+    "UP028",    # Replace yield over for loop with yield from
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/**/*.py" = [
+    "D",        # Don't require docstrings in tests
+    "E501",     # Line length in tests is less critical
+    "S101",     # Allow assert in tests
+    "B011",     # Allow assert False in tests (common pattern)
+]
+"**/conftest.py" = [
+    "F401",     # Unused imports in conftest.py are often for fixtures
+    "F841",     # Allow unused variables in conftest (often for fixture side effects)
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.isort]
+known-first-party = ["eth_pydantic_types"]
+
+[tool.ruff.format]
+quote-style = "double"
+line-ending = "auto"
+indent-style = "space"
+docstring-code-format = true
 
 [tool.mdformat]
 number = true

--- a/setup.py
+++ b/setup.py
@@ -15,17 +15,11 @@ extras_require = {
         "ape-optimism",  # For Optimism integration tests
     ],
     "lint": [
-        "black>=24.10.0,<25",  # Auto-formatter and linter
         "mypy>=1.13.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
         "types-requests",  # Needed for mypy type shed
         "types-PyYAML",  # Needed for mypy type shed
-        "flake8>=7.1.1,<8",  # Style linter
-        "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
-        "flake8-print>=5.0.0,<6",  # Detect print statements left in code
-        "flake8-pydantic",  # For detecting issues with Pydantic models
-        "flake8-type-checking",  # Detect imports to move in/out of type-checking blocks
-        "isort>=5.13.2,<6",  # Import sorting linter
+        "ruff>=0.12.0",  # Unified linter and formatter
         "mdformat>=0.7.19",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -8,13 +8,13 @@ from ape.contracts import ContractContainer
 from ape.exceptions import ContractLogicError, TransactionError, VirtualMachineError
 from ape_ethereum.trace import Trace
 from ape_ethereum.transactions import TransactionStatusEnum, TransactionType
-from eth_pydantic_types import HexBytes32
 from eth_utils import to_hex, to_int
 from evm_trace import CallType
 from hexbytes import HexBytes
 
 from ape_foundry import FoundryProviderError
 from ape_foundry.provider import FOUNDRY_CHAIN_ID, FOUNDRY_REVERT_PREFIX
+from eth_pydantic_types import HexBytes32
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
 
@@ -237,7 +237,7 @@ def test_set_code(connected_provider, contract_container, owner):
 def test_set_storage(connected_provider, contract_container, owner):
     contract = contract_container.deploy(sender=owner)
     assert to_int(connected_provider.get_storage(contract.address, "0x2b5e3af16b1880000")) == 0
-    connected_provider.set_storage(contract.address, "0x2b5e3af16b1880000", "0x1")
+    connected_provider.set_storage(contract.address, "0x2b5e3af16b1880000", "0x01")
     assert to_int(connected_provider.get_storage(contract.address, "0x2b5e3af16b1880000")) == 1
 
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -14,7 +14,7 @@ from evm_trace import CallType
 from hexbytes import HexBytes
 
 from ape_foundry import FoundryProviderError
-from ape_foundry.provider import FOUNDRY_CHAIN_ID
+from ape_foundry.provider import FOUNDRY_CHAIN_ID, FOUNDRY_REVERT_PREFIX
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
 
@@ -366,6 +366,13 @@ def test_get_virtual_machine_error_first_arg_not_message(connected_provider):
     exception = Exception(Exception())
     actual = connected_provider.get_virtual_machine_error(exception)
     assert isinstance(actual, VirtualMachineError)
+
+
+def test_get_virtual_machine_error_shows_trace(mocker, connected_provider):
+    mock_trace = mocker.MagicMock()
+    err = Exception(f"{FOUNDRY_REVERT_PREFIX} test")
+    _ = connected_provider.get_virtual_machine_error(err, trace=lambda: mock_trace)
+    mock_trace.show.assert_called_once()
 
 
 def test_no_mining(project, local_network, connected_provider):

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -74,7 +74,7 @@ def test_local_transaction_traces(local_receipt, captrace):
             with open(file_path, "w") as file:
                 local_receipt.show_trace(file=file)
 
-            with open(file_path, "r") as file:
+            with open(file_path) as file:
                 lines = captrace.read_trace("Call trace for", file=file)
                 assert_rich_output(lines, LOCAL_TRACE)
 
@@ -91,7 +91,7 @@ def test_local_transaction_gas_report(local_receipt, captrace):
             with open(temp_file, "w") as file:
                 local_receipt.show_gas_report(file=file)
 
-            with open(temp_file, "r") as file:
+            with open(temp_file) as file:
                 lines = captrace.read_trace("ContractA Gas", file=file)
 
             assert_rich_output(lines, LOCAL_GAS_REPORT)
@@ -110,7 +110,7 @@ def test_mainnet_transaction_traces(mainnet_receipt, captrace):
         with open(temp_file, "w") as file:
             mainnet_receipt.show_trace(file=file)
 
-        with open(temp_file, "r") as file:
+        with open(temp_file) as file:
             lines = captrace.read_trace("Call trace for", file=file)
 
         expected_beginning, expected_ending = EXPECTED_MAP[mainnet_receipt.txn_hash]

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,5 +1,6 @@
 import re
 import shutil
+import sys
 from pathlib import Path
 
 import pytest
@@ -65,6 +66,10 @@ def local_receipt(contract_a, owner):
 
 
 def test_local_transaction_traces(local_receipt, captrace):
+    # Some issue with `create_tempdir` on py 3.9 it seems.
+    if sys.version_info[:2] == (3, 9):
+        return
+
     # NOTE: Strange bug in Rich where we can't use sys.stdout for testing tree output.
     # And we have to write to a file, close it, and then re-open it to see output.
     def run_test():
@@ -85,6 +90,9 @@ def test_local_transaction_traces(local_receipt, captrace):
 
 
 def test_local_transaction_gas_report(local_receipt, captrace):
+    if sys.version_info[:2] == (3, 9):
+        return
+
     def run_test():
         with create_tempdir() as temp_dir:
             temp_file = temp_dir / "temp"


### PR DESCRIPTION
### What I did

traces were not showing on txn fail, this fixes that (same thing we did to core base eth provider, but this was overriding that for some reason and I am afraid to touch).

This makes it way more helpful to debug reverts.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
