### PR TITLE
refactor: add upstream request headers to fork command

### DIFF
--- a/ape_foundry/provider.py
+++ b/ape_foundry/provider.py
@@ -865,6 +865,14 @@ class FoundryForkProvider(FoundryProvider):
 
         cmd = super().build_command()
         cmd.extend(("--fork-url", self.fork_url))
+        upstream_headers = self.network_manager.get_request_headers(
+            self.forked_network.ecosystem.name,
+            self.forked_network.upstream_network.name,
+            self.upstream_provider_name,
+        )
+        for key, value in upstream_headers.items():
+            cmd.extend(("--fork-header", f"{key}: {value}"))
+
         if self.fork_block_number is not None:
             cmd.extend(("--fork-block-number", str(self.fork_block_number)))
 

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,7 @@ setup(
     url="https://github.com/ApeWorX/ape-foundry",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.8.35,<0.9",
-        # TODO: "eth-ape>=0.8.49,<0.9",
+        "eth-ape>=0.8.49,<0.9",
         "eth_pydantic_types>=0.2.0,<0.3",
         "evm-trace>=0.2.3,<0.3",
         "ethpm-types>=0.6.19,<0.7",

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ setup(
     url="https://github.com/ApeWorX/ape-foundry",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.8.34,<0.9",
+        "eth-ape @ git+https://github.com/ApeWorX/ape@codex/fix-authentication-for-ape-foundry"
+        # TODO: "eth-ape>=0.8.49,<0.9",
         "eth_pydantic_types>=0.2.0,<0.3",
         "evm-trace>=0.2.3,<0.3",
         "ethpm-types>=0.6.19,<0.7",

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     url="https://github.com/ApeWorX/ape-foundry",
     include_package_data=True,
     install_requires=[
-        "eth-ape @ git+https://github.com/ApeWorX/ape@codex/fix-authentication-for-ape-foundry"
+        "eth-ape>=0.8.35,<0.9",
         # TODO: "eth-ape>=0.8.49,<0.9",
         "eth_pydantic_types>=0.2.0,<0.3",
         "evm-trace>=0.2.3,<0.3",

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import PropertyMock
 
 import pytest
 from ape import convert, reverts
@@ -13,7 +14,7 @@ from evm_trace import CallType
 from hexbytes import HexBytes
 
 from ape_foundry import FoundryProviderError
-from ape_foundry.provider import FOUNDRY_CHAIN_ID, FOUNDRY_REVERT_PREFIX
+from ape_foundry.provider import FOUNDRY_CHAIN_ID, FOUNDRY_REVERT_PREFIX, FoundryForkProvider
 from eth_pydantic_types import HexBytes32
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
@@ -476,6 +477,31 @@ def test_prepare_tx_with_max_gas(tx_type, connected_provider, ethereum, owner):
     # NOTE: The local network by default uses max_gas.
     actual = connected_provider.prepare_transaction(tx)
     assert actual.gas_limit == connected_provider.max_gas
+
+
+def test_fork_build_command_adds_upstream_request_headers(mocker, name, mainnet_fork):
+    provider = mainnet_fork.get_provider(name)
+    mocker.patch.object(
+        FoundryForkProvider,
+        "fork_url",
+        new_callable=PropertyMock,
+        return_value="https://example.com",
+    )
+    get_request_headers = mocker.patch.object(
+        provider.network_manager,
+        "get_request_headers",
+        return_value={
+            "Authorization": "Bearer test-token",
+            "X-Trace": "trace-id",
+        },
+    )
+
+    cmd = provider.build_command()
+
+    get_request_headers.assert_called_once_with("ethereum", "mainnet", provider.upstream_provider_name)
+    assert cmd.count("--fork-header") == 2
+    assert "Authorization: Bearer test-token" in cmd
+    assert "X-Trace: trace-id" in cmd
 
 
 def test_disable_block_gas_limit(project, disconnected_provider):


### PR DESCRIPTION
### Motivation
- Ensure that when forking an upstream network, any required HTTP request headers (like auth or tracing headers) are forwarded to the forked node so upstream requests include the same context.

### Description
- Retrieve upstream headers via `network_manager.get_request_headers` using `forked_network.ecosystem.name`, `forked_network.upstream_network.name`, and `upstream_provider_name` inside `FoundryForkProvider.build_command`.
- Append each returned header to the foundry/anvil command as `--fork-header "key: value"` so they are passed when starting the fork.
- Add an import for `PropertyMock` and a new unit test `test_fork_build_command_adds_upstream_request_headers` in `tests/test_provider.py` that verifies `get_request_headers` is called and `--fork-header` entries are included in the built command.

### Testing
- Ran the new unit test `pytest tests/test_provider.py::test_fork_build_command_adds_upstream_request_headers` and it passed.
- Ran the provider test file `pytest tests/test_provider.py` to ensure no regressions in provider behavior and all tests passed.

Requires: https://github.com/ApeWorX/ape/pull/2764

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb6497c00083339b2b6ebbad5c51d4)